### PR TITLE
Converted slots to @render, fix props errors

### DIFF
--- a/packages/ui/src/lib/components/Stage/components/Scene/Scene.svelte
+++ b/packages/ui/src/lib/components/Stage/components/Scene/Scene.svelte
@@ -105,5 +105,5 @@
 
   <!-- Map overlays that scale with the scene -->
   <GridLayer grid={props.grid} display={props.display} sceneZoom={props.scene.zoom} />
-  <WeatherLayer props={props.weather} z={40} resolution={props.display.resolution} />
+  <WeatherLayer props={props.weather} resolution={props.display.resolution} />
 </T.Object3D>

--- a/packages/ui/src/lib/components/Stage/materials/GridMaterial.svelte
+++ b/packages/ui/src/lib/components/Stage/materials/GridMaterial.svelte
@@ -52,7 +52,11 @@
   });
 </script>
 
+{#snippet attachMaterial()}
+  {material}
+{/snippet}
+
 <!-- Export the material to be used in the parent component -->
 <T is={material} {fragmentShader} {vertexShader} transparent={true} depthTest={false}>
-  <slot ref={material} />
+  {@render attachMaterial()}
 </T>

--- a/packages/ui/src/lib/components/Stage/materials/PingMaterial.svelte
+++ b/packages/ui/src/lib/components/Stage/materials/PingMaterial.svelte
@@ -57,7 +57,11 @@
   });
 </script>
 
+{#snippet attachMaterial()}
+  {material}
+{/snippet}
+
 <!-- Export the material to be used in the parent component -->
 <T is={material} {fragmentShader} {vertexShader} transparent={true} depthTest={false}>
-  <slot ref={material} />
+  {@render attachMaterial()}
 </T>

--- a/packages/ui/src/lib/components/Stage/materials/WeatherMaterial.svelte
+++ b/packages/ui/src/lib/components/Stage/materials/WeatherMaterial.svelte
@@ -7,7 +7,7 @@
 
   interface Props {
     props: WeatherProps;
-    resolution: THREE.Vector2;
+    resolution: { x: number; y: number };
   }
 
   let { invalidate } = useThrelte();
@@ -45,7 +45,11 @@
   });
 </script>
 
+{#snippet attachMaterial()}
+  {material}
+{/snippet}
+
 <!-- Export the material to be used in the parent component -->
 <T is={material} {fragmentShader} {vertexShader} transparent={true} depthTest={false}>
-  <slot ref={material} />
+  {@render attachMaterial()}
 </T>


### PR DESCRIPTION
# What Changed
- Converted `<slot>` to `{@render}`
- Removed extra prop