### PR TITLE
Fix Fog of War sequencing issue

### DIFF
--- a/packages/ui/src/lib/components/Stage/components/FogOfWarLayer/FogOfWarLayer.svelte
+++ b/packages/ui/src/lib/components/Stage/components/FogOfWarLayer/FogOfWarLayer.svelte
@@ -61,6 +61,7 @@
   $effect(() => {
     if (!mapSize) return;
 
+    outlineMaterial.visible = isActive;
     outlineMaterial.uniforms.uTextureSize.value = new THREE.Vector2(mapSize.width, mapSize.height);
     outlineMaterial.uniforms.uOutlineColor.value = new THREE.Color(props.outline.color);
     outlineMaterial.uniforms.uOutlineThickness.value = props.outline.thickness;
@@ -72,11 +73,6 @@
     if (props.tool.type === ToolType.Rectangle || props.tool.type === ToolType.Ellipse) {
       outlineMaterial.visible = false;
     }
-  });
-
-  // Show/hide the outline material when the layer is active
-  $effect(() => {
-    outlineMaterial.visible = isActive;
   });
 
   function onMouseDown(e: MouseEvent, p: THREE.Vector2 | null): void {

--- a/packages/ui/src/lib/components/Stage/components/WeatherLayer/WeatherLayer.svelte
+++ b/packages/ui/src/lib/components/Stage/components/WeatherLayer/WeatherLayer.svelte
@@ -88,11 +88,6 @@
   $effect(() => {
     if (!mapSize || !particleCamera) return;
 
-    console.log('Updating particle camera');
-    console.log('aspectRatio', aspectRatio);
-    console.log('size', $size.width, $size.height);
-    console.log('mapSize', mapSize?.width, mapSize?.height);
-
     particleCamera.aspect = aspectRatio;
     particleCamera.fov = props.fov;
     particleCamera.updateMatrixWorld();
@@ -102,11 +97,6 @@
   // Add DOF effect to the composer
   $effect(() => {
     if (!particleScene || !particleCamera) return;
-
-    console.log('Updating composer');
-    console.log('aspectRatio', aspectRatio);
-    console.log('size', $size.width, $size.height);
-    console.log('mapSize', mapSize?.width, mapSize?.height);
 
     composer.setMainCamera(particleCamera);
     composer.setMainScene(particleScene);


### PR DESCRIPTION
# What Changed
This PR fixes a race condition in the `FogOfWarLayer` component when a new map is loaded. When the map size is changed, the fog layer is reset. This would sometimes occur after the pre-existing fog of war image data was loaded.

These two operations have now been separated, so the reset only occurs if a scene has no pre-existing fog of war data. Additionally, the fog of war image update was pulled into a separate effect.