### PR TITLE
onMouseDown fix for Firefox in Markers

### DIFF
--- a/packages/ui/src/lib/components/Stage/components/MarkerLayer/MarkerLayer.svelte
+++ b/packages/ui/src/lib/components/Stage/components/MarkerLayer/MarkerLayer.svelte
@@ -51,9 +51,13 @@
   function onMouseDown(e: MouseEvent | TouchEvent, coords: THREE.Vector2 | null) {
     if (!coords) return;
 
+    // Check if TouchEvent is defined in the browser before using it
+    const isTouchEvent = typeof TouchEvent !== 'undefined' && e instanceof TouchEvent;
+    const isMouseEvent = e instanceof MouseEvent;
+
     // Verify the primary mouse/touch was used
-    if (e instanceof MouseEvent && e.button !== 0) return;
-    if (e instanceof TouchEvent && e.touches.length !== 1) return;
+    if (isMouseEvent && e.button !== 0) return;
+    if (isTouchEvent && (e as TouchEvent).touches.length !== 1) return;
 
     const gridCoords = new THREE.Vector2(coords.x - display.resolution.x / 2, coords.y - display.resolution.y / 2);
 


### PR DESCRIPTION
Firefox was causing an error because `TouchEvent` doesn't exist in Desktop. It works fine in Chrome, which is why you likely didn't see it.