### PR TITLE
Revert "Fix incorrect weather aspect ratio"

### DIFF
--- a/packages/ui/src/lib/components/Stage/components/Scene/Scene.svelte
+++ b/packages/ui/src/lib/components/Stage/components/Scene/Scene.svelte
@@ -58,8 +58,6 @@
     // Configure renderer
     renderer.setClearColor(0, 0);
     renderer.setPixelRatio(window.devicePixelRatio);
-    renderer.setSize($size.width, $size.height);
-    composer.setSize($size.width, $size.height);
   });
 
   // Effect to update post-processing settings when props change
@@ -69,6 +67,7 @@
     // Need to convert the LUT to a LookupTexture
     Promise.resolve(getLUT(postProcessing.lut.url))
       .then((lut) => {
+        composer.setSize($size.width, $size.height);
         composer.removeAllPasses();
 
         const effects = [];
@@ -146,9 +145,6 @@
   useTask(
     (dt) => {
       if (!scene || !renderer || !camera) return;
-
-      // Reset renderer size to match the canvas size (has no effect if already set)
-      renderer.setSize($size.width, $size.height);
 
       // Render main scene with post-processing
       camera.current.layers.set(SceneLayer.Main);

--- a/packages/ui/src/lib/components/Stage/components/Stage/Stage.svelte
+++ b/packages/ui/src/lib/components/Stage/components/Stage/Stage.svelte
@@ -68,7 +68,7 @@
 
 <div style="height: 100%; width: 100%;">
   <Canvas>
-    <T.Mesh scale={[100000, 100000, 1]} layers={[SceneLayerOrder.Background]}>
+    <T.Mesh scale={[1000, 1000, 1]} layers={[SceneLayerOrder.Background]}>
       <T.PlaneGeometry />
       <T.MeshBasicMaterial color={props.backgroundColor} />
     </T.Mesh>

--- a/packages/ui/src/lib/components/Stage/components/WeatherLayer/WeatherLayer.svelte
+++ b/packages/ui/src/lib/components/Stage/components/WeatherLayer/WeatherLayer.svelte
@@ -11,7 +11,6 @@
   import AshPreset from './presets/AshPreset';
 
   import { DepthOfFieldEffect, EffectComposer, EffectPass, RenderPass, CopyPass } from 'postprocessing';
-  import { onMount } from 'svelte';
 
   interface Props extends ThrelteProps<typeof THREE.Mesh> {
     props: WeatherLayerProps;
@@ -20,7 +19,23 @@
 
   const { props, mapSize, ...meshProps }: Props = $props();
 
-  const { renderer, renderStage } = useThrelte();
+  const { renderer, size, renderStage } = useThrelte();
+
+  let mesh: THREE.Mesh = $state(new THREE.Mesh());
+  let particleScene: THREE.Scene | undefined = $state(undefined);
+  let particleCamera: THREE.PerspectiveCamera | undefined = $state(undefined);
+
+  const aspectRatio = $derived((mapSize?.width ?? 1) / (mapSize?.height ?? 1));
+
+  // Create render target
+  const renderTarget = new THREE.WebGLRenderTarget(1, 1, {
+    format: THREE.RGBAFormat,
+    stencilBuffer: false
+  });
+
+  const composer = new EffectComposer(renderer);
+  composer.autoRenderToScreen = false;
+  composer.outputBuffer = renderTarget;
 
   let weatherPreset = $derived.by(() => {
     let preset: WeatherLayerPreset;
@@ -62,22 +77,6 @@
     return preset;
   });
 
-  let mesh: THREE.Mesh = $state(new THREE.Mesh());
-  let particleScene = $state(new THREE.Scene());
-  let particleCamera = $state(new THREE.PerspectiveCamera(90, 1, 0.01, 10));
-  particleCamera.position.set(0, 0, -1);
-  particleCamera.rotation.x = Math.PI;
-
-  // Create render target
-  const renderTarget = new THREE.WebGLRenderTarget(1, 1, {
-    format: THREE.RGBAFormat,
-    stencilBuffer: false
-  });
-
-  const composer = new EffectComposer(renderer);
-  composer.autoRenderToScreen = false;
-  composer.outputBuffer = renderTarget;
-
   // Create quad material using render target texture
   const quadMaterial = $derived(
     new THREE.MeshBasicMaterial({
@@ -92,19 +91,24 @@
     })
   );
 
-  onMount(() => {
-    if (particleCamera && particleScene && mapSize) {
-      composer.setMainCamera(particleCamera);
-      composer.setMainScene(particleScene);
-      composer.setSize(mapSize.width, mapSize.height);
-      renderTarget.setSize(mapSize.width, mapSize.height);
-    }
+  // Position the render target camera
+  $effect(() => {
+    if (!mapSize || !particleCamera) return;
+
+    particleCamera.aspect = aspectRatio;
+    particleCamera.fov = weatherPreset.fov;
+    particleCamera.updateMatrixWorld();
+    particleCamera.updateProjectionMatrix();
   });
 
   // Add DOF effect to the composer
   $effect(() => {
-    if (!particleScene || !particleCamera || !mapSize) return;
+    if (!particleScene || !particleCamera) return;
 
+    composer.setMainCamera(particleCamera);
+    composer.setMainScene(particleScene);
+    composer.setSize($size.width, $size.height);
+    renderTarget.setSize($size.width, $size.height);
     composer.removeAllPasses();
 
     // Add render pass
@@ -117,8 +121,8 @@
         focusDistance: weatherPreset.depthOfField.focus,
         focalLength: weatherPreset.depthOfField.focalLength,
         bokehScale: weatherPreset.depthOfField.bokehScale,
-        resolutionX: mapSize.width,
-        resolutionY: mapSize.height
+        resolutionX: $size.width,
+        resolutionY: $size.height
       });
       dofEffect.blurPass.kernelSize = weatherPreset.depthOfField.kernelSize;
       composer.addPass(new EffectPass(particleCamera, dofEffect));
@@ -127,20 +131,10 @@
     }
   });
 
-  // If map sizes change, update the camera and render target
-  $effect(() => {
-    if (!mapSize) return;
-    particleCamera.aspect = mapSize.width / mapSize.height;
-    particleCamera.fov = weatherPreset.fov;
-    particleCamera.updateProjectionMatrix();
-    renderTarget.setSize(mapSize.width, mapSize.height);
-    composer.setSize(mapSize.width, mapSize.height);
-  });
-
   // Custom render task
   useTask(
     (dt) => {
-      if (!particleScene || !particleCamera || !mapSize) return;
+      if (!particleScene || !particleCamera) return;
 
       particleScene.visible = true;
 
@@ -156,8 +150,8 @@
 </script>
 
 <!-- Hidden scene that renders to the render target -->
-<T.Scene is={particleScene} visible={false}>
-  <T.PerspectiveCamera is={particleCamera} manual />
+<T.Scene bind:ref={particleScene} visible={false}>
+  <T.PerspectiveCamera bind:ref={particleCamera} near={0.01} far={10} position={[0, 0, -1]} rotation.x={Math.PI} />
   <ParticleSystem props={weatherPreset.particles} opacity={weatherPreset.opacity} intensity={weatherPreset.intensity} />
 </T.Scene>
 

--- a/packages/ui/src/lib/components/Stage/shaders/Particles.vert
+++ b/packages/ui/src/lib/components/Stage/shaders/Particles.vert
@@ -41,11 +41,13 @@ void main() {
   pos.xy = rotated + center;
 
   pos += vAge * velocity;
+    // Scale point size based on distance from camera
+  float distanceToCamera = length(modelViewMatrix * vec4(pos, 1.0));
 
   vUv = uv;
 
   vec4 transformedPosition = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
-  vPos = transformedPosition.xyz;
+  vPos = transformedPosition.xyz / transformedPosition.w;
 
   gl_Position = transformedPosition;
 }


### PR DESCRIPTION
Reverts Siege-Perilous/tableslayer#216

@dgreenheck Well, that was a poor idea on my part. Reverting this because of the performance hit. I didn't notice it till I started making edits.