### PR TITLE
Adds a 15MB limit for file uploads

### DIFF
--- a/apps/web/src/lib/components/GameSession/MapControls.svelte
+++ b/apps/web/src/lib/components/GameSession/MapControls.svelte
@@ -41,7 +41,7 @@
 </script>
 
 <div class="mapControls">
-  <Text size="0.85rem" color="var(--fgMuted)">Maps must be under 5MB in size.</Text>
+  <Text size="0.85rem" color="var(--fgMuted)">Maps must be under 15MB in size.</Text>
   <Spacer size={2} />
   <Button onclick={() => handleMapImageChange(selectedScene.id)}>Replace map</Button>
   <Spacer />

--- a/apps/web/src/lib/queries/file.ts
+++ b/apps/web/src/lib/queries/file.ts
@@ -48,6 +48,11 @@ export const useUploadFileMutation = () => {
   return mutationFactory<{ file: File; folder: string }, { userId: string; fileId: number; location: string }, Error>({
     mutationKey: ['uploadFile'],
     mutationFn: async ({ file, folder }) => {
+      const MAX_FILE_SIZE = 15 * 1024 * 1024;
+      if (file.size > MAX_FILE_SIZE) {
+        throw new Error('File size exceeds the 15MB limit');
+      }
+
       const fileId = uuidv4();
       const fileExtension = mime.getExtension(file.type);
       const fileName = `${folder}/${fileId}.${fileExtension}`;


### PR DESCRIPTION
Fixes https://github.com/Siege-Perilous/tableslayer/issues/251

Awhile ago I switched to using Cloudflare presigned URLs for file uploads. This removed the file size restriction. I'm adding it generically across all file uploads through the mutation, so that users will get proper error feedback.