### PR TITLE
Mouse panning should take scene rotation into account

### DIFF
--- a/apps/docs/src/routes/(components)/stage/+page.svelte
+++ b/apps/docs/src/routes/(components)/stage/+page.svelte
@@ -150,12 +150,23 @@
   function onMouseMove(e: MouseEvent) {
     if (!(e.buttons === 1 || e.buttons === 2)) return;
 
+    // Get rotation for both map and scene transformations
+    const rotation = stageProps.scene.rotation;
+    const radians = (Math.PI / 180) * rotation;
+
+    // Calculate rotated movement vectors
+    const rotatedMovementX = e.movementX * Math.cos(radians) + e.movementY * Math.sin(radians);
+    const rotatedMovementY = -e.movementX * Math.sin(radians) + e.movementY * Math.cos(radians);
+
     if (e.shiftKey) {
-      stageProps.map.offset.x += e.movementX / stageProps.scene.zoom;
-      stageProps.map.offset.y -= e.movementY / stageProps.scene.zoom;
+      // Apply rotation to movement for map offset
+      const movementFactor = 1 / stageProps.scene.zoom;
+      stageProps.map.offset.x += rotatedMovementX * movementFactor;
+      stageProps.map.offset.y -= rotatedMovementY * movementFactor;
     } else if (e.ctrlKey) {
-      stageProps.scene.offset.x += e.movementX;
-      stageProps.scene.offset.y -= e.movementY;
+      // Scene offset also needs rotation adjustment
+      stageProps.scene.offset.x += rotatedMovementX;
+      stageProps.scene.offset.y -= rotatedMovementY;
     }
   }
 

--- a/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
+++ b/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
@@ -334,14 +334,25 @@
     const finalNormalizedX = rotated.x + 0.5;
     const finalNormalizedY = rotated.y + 0.5;
 
-    // Handle panning (existing logic)
+    // Handle panning with rotation adjustment
     if (e.buttons === 1 || e.buttons === 2) {
+      // Get rotation for both map and scene transformations
+      const rotation = stageProps.scene.rotation;
+      const radians = (Math.PI / 180) * rotation;
+
+      // Calculate rotated movement vectors
+      const rotatedMovementX = e.movementX * Math.cos(radians) + e.movementY * Math.sin(radians);
+      const rotatedMovementY = -e.movementX * Math.sin(radians) + e.movementY * Math.cos(radians);
+
       if (e.shiftKey) {
-        stageProps.map.offset.x += e.movementX / stageProps.scene.zoom;
-        stageProps.map.offset.y -= e.movementY / stageProps.scene.zoom;
+        // Apply rotation to movement for map offset
+        const movementFactor = 1 / stageProps.scene.zoom;
+        stageProps.map.offset.x += rotatedMovementX * movementFactor;
+        stageProps.map.offset.y -= rotatedMovementY * movementFactor;
       } else if (e.ctrlKey) {
-        stageProps.scene.offset.x += e.movementX;
-        stageProps.scene.offset.y -= e.movementY;
+        // Scene offset also needs rotation adjustment
+        stageProps.scene.offset.x += rotatedMovementX;
+        stageProps.scene.offset.y -= rotatedMovementY;
       }
 
       // Use our proper throttled update (replaces manual throttling)

--- a/apps/web/src/routes/(app)/[party]/[gameSession]/share/+page@.svelte
+++ b/apps/web/src/routes/(app)/[party]/[gameSession]/share/+page@.svelte
@@ -87,7 +87,7 @@
         // Override stage props with the updated props from the websocket
         ...payload.stageProps,
         // Don't allow rotate and zoom from the editor
-        scene: { ...stageProps.scene, autoFit: true },
+        scene: { ...stageProps.scene, autoFit: true, offset: { x: 0, y: 0 } },
         // Don't allow erase mode
         activeLayer: MapLayerType.None,
         // Mode 1 is for player view


### PR DESCRIPTION
Fixes https://github.com/Siege-Perilous/tableslayer/issues/257

- Makes up/down panning of the map / scene work relative to the scene rotation. This feels more natural.
- Makes sure the offset doesn't get passed to the playfield