### PR TITLE
Websocket batched updates

### DIFF
--- a/apps/web/src/lib/components/GameSession/EffectsControls.svelte
+++ b/apps/web/src/lib/components/GameSession/EffectsControls.svelte
@@ -1,18 +1,17 @@
 <script lang="ts">
   import { type ZodIssue } from 'zod';
   import { FormControl, type StageProps, Select, Spacer, InputSlider, Text, Hr, RadioButton } from '@tableslayer/ui';
+  import { queuePropertyUpdate } from '$lib/utils';
   import { ToneMappingMode } from 'postprocessing';
   import type { SelectParty } from '$lib/db/app/schema';
   import type { Thumb } from '$lib/server';
   import { PartyPlanSelector } from '../party';
 
   let {
-    socketUpdate,
     stageProps = $bindable(),
     errors,
     party
   }: {
-    socketUpdate: () => void;
     stageProps: StageProps;
     errors: ZodIssue[] | undefined;
     party: SelectParty & Thumb;
@@ -64,19 +63,21 @@
   // Weather toggle
   const handleLutChange = (lutUrl: string) => {
     if (lutUrl === 'none') {
-      stageProps.postProcessing.lut.url = null;
-      socketUpdate();
+      queuePropertyUpdate(stageProps, ['postProcessing', 'lut', 'url'], null, 'control');
       return;
     }
-    stageProps.postProcessing.lut.url = lutUrl;
-    stageProps.postProcessing.lut.enabled = true;
-    socketUpdate();
+    queuePropertyUpdate(stageProps, ['postProcessing', 'lut', 'url'], lutUrl, 'control');
+    queuePropertyUpdate(stageProps, ['postProcessing', 'lut', 'enabled'], true, 'control');
   };
 
   const handleToneChange = (value: string) => {
     const toneMapping = toneMappingOptions.find((option) => option.value === value) || toneMappingOptions[0];
-    stageProps.postProcessing.toneMapping.mode = toneMapping.mode as ToneMappingMode;
-    socketUpdate();
+    queuePropertyUpdate(
+      stageProps,
+      ['postProcessing', 'toneMapping', 'mode'],
+      toneMapping.mode as ToneMappingMode,
+      'control'
+    );
   };
 </script>
 
@@ -125,6 +126,13 @@
           max={0.02}
           step={0.001}
           bind:value={stageProps.postProcessing.chromaticAberration.offset}
+          oninput={() =>
+            queuePropertyUpdate(
+              stageProps,
+              ['postProcessing', 'chromaticAberration', 'offset'],
+              stageProps.postProcessing.chromaticAberration.offset,
+              'control'
+            )}
         />
       {/snippet}
     </FormControl>
@@ -142,6 +150,13 @@
             max={10}
             step={0.05}
             bind:value={stageProps.postProcessing.bloom.intensity}
+            oninput={() =>
+              queuePropertyUpdate(
+                stageProps,
+                ['postProcessing', 'bloom', 'intensity'],
+                stageProps.postProcessing.bloom.intensity,
+                'control'
+              )}
           />
         {/snippet}
       </FormControl>
@@ -153,6 +168,13 @@
             max={0.5}
             step={0.01}
             bind:value={stageProps.postProcessing.bloom.radius}
+            oninput={() =>
+              queuePropertyUpdate(
+                stageProps,
+                ['postProcessing', 'bloom', 'radius'],
+                stageProps.postProcessing.bloom.radius,
+                'control'
+              )}
           />
         {/snippet}
       </FormControl>
@@ -167,6 +189,13 @@
             max={1}
             step={0.01}
             bind:value={stageProps.postProcessing.bloom.threshold}
+            oninput={() =>
+              queuePropertyUpdate(
+                stageProps,
+                ['postProcessing', 'bloom', 'threshold'],
+                stageProps.postProcessing.bloom.threshold,
+                'control'
+              )}
           />
         {/snippet}
       </FormControl>
@@ -178,6 +207,13 @@
             max={1}
             step={0.01}
             bind:value={stageProps.postProcessing.bloom.smoothing}
+            oninput={() =>
+              queuePropertyUpdate(
+                stageProps,
+                ['postProcessing', 'bloom', 'smoothing'],
+                stageProps.postProcessing.bloom.smoothing,
+                'control'
+              )}
           />
         {/snippet}
       </FormControl>
@@ -186,7 +222,20 @@
     <div class="effectsControls__grid">
       <FormControl label="Levels" name="effectsBloomLevels" {errors}>
         {#snippet input({ inputProps })}
-          <InputSlider {...inputProps} min={0} max={16} step={1} bind:value={stageProps.postProcessing.bloom.levels} />
+          <InputSlider
+            {...inputProps}
+            min={0}
+            max={16}
+            step={1}
+            bind:value={stageProps.postProcessing.bloom.levels}
+            oninput={() =>
+              queuePropertyUpdate(
+                stageProps,
+                ['postProcessing', 'bloom', 'levels'],
+                stageProps.postProcessing.bloom.levels,
+                'control'
+              )}
+          />
         {/snippet}
       </FormControl>
       <FormControl label="Mip-map blur" name="effectsBloomBlur" {errors}>
@@ -199,8 +248,7 @@
               { label: 'off', value: 'false' }
             ]}
             onSelectedChange={(value) => {
-              stageProps.postProcessing.bloom.mipmapBlur = value === 'true';
-              socketUpdate();
+              queuePropertyUpdate(stageProps, ['postProcessing', 'bloom', 'mipmapBlur'], value === 'true', 'control');
             }}
           />
         {/snippet}

--- a/apps/web/src/lib/components/GameSession/FogControls.svelte
+++ b/apps/web/src/lib/components/GameSession/FogControls.svelte
@@ -7,7 +7,7 @@
     type StageExports,
     Spacer
   } from '@tableslayer/ui';
-  import { generateGradientColors, to8CharHex } from '$lib/utils';
+  import { generateGradientColors, to8CharHex, queuePropertyUpdate } from '$lib/utils';
   import chroma from 'chroma-js';
 
   let {
@@ -25,19 +25,14 @@
   const handleFogColorUpdate = (cd: ColorUpdatePayload) => {
     const fogColor = chroma(cd.hex).hex('rgb');
     const fogColors = generateGradientColors(fogColor);
-    stageProps.fogOfWar = {
-      ...stageProps.fogOfWar,
-      opacity: cd.rgba.a,
-      noise: {
-        ...stageProps.fogOfWar.noise,
-        baseColor: fogColors[0],
-        fogColor1: fogColors[1],
-        fogColor2: fogColors[2],
-        fogColor3: fogColors[3],
-        fogColor4: fogColors[4]
-      }
-    };
-    socketUpdate();
+
+    // Update each property individually
+    queuePropertyUpdate(stageProps, ['fogOfWar', 'opacity'], cd.rgba.a, 'control');
+    queuePropertyUpdate(stageProps, ['fogOfWar', 'noise', 'baseColor'], fogColors[0], 'control');
+    queuePropertyUpdate(stageProps, ['fogOfWar', 'noise', 'fogColor1'], fogColors[1], 'control');
+    queuePropertyUpdate(stageProps, ['fogOfWar', 'noise', 'fogColor2'], fogColors[2], 'control');
+    queuePropertyUpdate(stageProps, ['fogOfWar', 'noise', 'fogColor3'], fogColors[3], 'control');
+    queuePropertyUpdate(stageProps, ['fogOfWar', 'noise', 'fogColor4'], fogColors[4], 'control');
   };
 
   $effect(() => {
@@ -54,6 +49,7 @@
     <Button
       onclick={() => {
         stage.fogOfWar.clear();
+        // Still need socketUpdate here since this is a more complex operation handled by the stage
         socketUpdate();
       }}
     >

--- a/apps/web/src/lib/components/GameSession/FogControls.svelte
+++ b/apps/web/src/lib/components/GameSession/FogControls.svelte
@@ -49,7 +49,6 @@
     <Button
       onclick={() => {
         stage.fogOfWar.clear();
-        // Still need socketUpdate here since this is a more complex operation handled by the stage
         socketUpdate();
       }}
     >

--- a/apps/web/src/lib/components/GameSession/GridControls.svelte
+++ b/apps/web/src/lib/components/GameSession/GridControls.svelte
@@ -27,12 +27,10 @@
   } from '$lib/utils';
 
   let {
-    socketUpdate,
     stageProps = $bindable(),
     party,
     errors
   }: {
-    socketUpdate: () => void;
     handleSelectActiveControl: (control: string) => void;
     activeControl: string;
     stageProps: StageProps;

--- a/apps/web/src/lib/components/GameSession/GridControls.svelte
+++ b/apps/web/src/lib/components/GameSession/GridControls.svelte
@@ -22,7 +22,8 @@
     getResolutionOption,
     getTvDimensions,
     to8CharHex,
-    getTvSizeFromPhysicalDimensions
+    getTvSizeFromPhysicalDimensions,
+    queuePropertyUpdate
   } from '$lib/utils';
 
   let {
@@ -58,39 +59,28 @@
   // Turn the local concept of TV size into the stageProps format
   const handleTvSizeChange = (diagonalSize: number) => {
     const { width, height } = getTvDimensions(diagonalSize);
-    stageProps.display.size = {
-      x: width,
-      y: height
-    };
-    socketUpdate();
+    queuePropertyUpdate(stageProps, ['display', 'size', 'x'], width, 'control');
+    queuePropertyUpdate(stageProps, ['display', 'size', 'y'], height, 'control');
   };
 
   // We provide typical TV sizes as options, but save them as x and y values
   const handleSelectedResolution = (newSelected: string) => {
     const selectedResolution = tvResolutionOptions.find((option) => option.value === newSelected)!;
-    stageProps.display.resolution = {
-      x: selectedResolution.width,
-      y: selectedResolution.height
-    };
-    socketUpdate();
+    queuePropertyUpdate(stageProps, ['display', 'resolution', 'x'], selectedResolution.width, 'control');
+    queuePropertyUpdate(stageProps, ['display', 'resolution', 'y'], selectedResolution.height, 'control');
     return selectedResolution;
   };
 
   // Hex or Square grid toggle
   const handleGridTypeChange = (gridType: number) => {
-    stageProps.grid.gridType = gridType;
-    socketUpdate();
+    queuePropertyUpdate(stageProps, ['grid', 'gridType'], gridType, 'control');
   };
 
   // Ensure the handleGridColorUpdate function is also typed with ColorUpdatePayload
   const handleGridColorUpdate = (cd: ColorUpdatePayload) => {
     const gridColor = chroma(cd.hex).hex('rgb');
-    stageProps.grid = {
-      ...stageProps.grid,
-      lineColor: gridColor,
-      opacity: cd.rgba.a
-    };
-    socketUpdate();
+    queuePropertyUpdate(stageProps, ['grid', 'lineColor'], gridColor, 'control');
+    queuePropertyUpdate(stageProps, ['grid', 'opacity'], cd.rgba.a, 'control');
   };
 
   /** Padding
@@ -100,9 +90,8 @@
   let localPadding = $state(stageProps.display.padding.x);
 
   const handlePaddingChange = () => {
-    stageProps.display.padding.x = localPadding;
-    stageProps.display.padding.y = localPadding;
-    socketUpdate();
+    queuePropertyUpdate(stageProps, ['display', 'padding', 'x'], localPadding, 'control');
+    queuePropertyUpdate(stageProps, ['display', 'padding', 'y'], localPadding, 'control');
   };
 
   // Local state and conversion for grid color, tv size and padding

--- a/apps/web/src/lib/components/GameSession/SceneControls.svelte
+++ b/apps/web/src/lib/components/GameSession/SceneControls.svelte
@@ -259,7 +259,6 @@
             {#if scene.id === 'grid'}
               <GridControls
                 bind:stageProps
-                {socketUpdate}
                 {handleSelectActiveControl}
                 {activeControl}
                 {party}
@@ -288,11 +287,11 @@
             {:else if scene.id === 'play'}
               <PlayControls {socketUpdate} {party} {gameSession} {selectedScene} {activeScene} />
             {:else if scene.id === 'weather'}
-              <WeatherControls bind:stageProps {socketUpdate} {errors} />
+              <WeatherControls bind:stageProps {errors} />
             {:else if scene.id === 'edge'}
               <EdgeControls bind:stageProps {socketUpdate} {errors} {party} />
             {:else if scene.id === 'effects'}
-              <EffectsControls bind:stageProps {socketUpdate} {errors} {party} />
+              <EffectsControls bind:stageProps {errors} {party} />
             {/if}
           {/snippet}
         </Popover>

--- a/apps/web/src/lib/components/GameSession/WeatherControls.svelte
+++ b/apps/web/src/lib/components/GameSession/WeatherControls.svelte
@@ -12,7 +12,7 @@
     RadioButton,
     Label
   } from '@tableslayer/ui';
-  import { to8CharHex } from '$lib/utils';
+  import { to8CharHex, queuePropertyUpdate } from '$lib/utils';
   import chroma from 'chroma-js';
 
   let {
@@ -31,8 +31,7 @@
 
   // Weather toggle
   const handleWeatherTypeChange = (weatherType: string) => {
-    stageProps.weather.type = Number(weatherType);
-    socketUpdate();
+    queuePropertyUpdate(stageProps, ['weather', 'type'], Number(weatherType), 'control');
   };
 
   const weatherTypes = [
@@ -44,9 +43,8 @@
   ];
 
   const handleFogColorUpdate = (cd: ColorUpdatePayload) => {
-    stageProps.fog.color = chroma(cd.hex).hex('rgb');
-    stageProps.fog.opacity = cd.rgba.a;
-    socketUpdate();
+    queuePropertyUpdate(stageProps, ['fog', 'color'], chroma(cd.hex).hex('rgb'), 'control');
+    queuePropertyUpdate(stageProps, ['fog', 'opacity'], cd.rgba.a, 'control');
   };
 </script>
 
@@ -63,7 +61,14 @@
   </FormControl>
   <FormControl label="Field of view" name="weatherFov" {errors}>
     {#snippet input({ inputProps })}
-      <InputSlider {...inputProps} min={10} max={120} step={1} bind:value={stageProps.weather.fov} />
+      <InputSlider
+        {...inputProps}
+        min={10}
+        max={120}
+        step={1}
+        bind:value={stageProps.weather.fov}
+        oninput={() => queuePropertyUpdate(stageProps, ['weather', 'fov'], stageProps.weather.fov, 'control')}
+      />
     {/snippet}
   </FormControl>
 </div>
@@ -78,6 +83,7 @@
         max={1}
         step={0.05}
         bind:value={stageProps.weather.opacity}
+        oninput={() => queuePropertyUpdate(stageProps, ['weather', 'opacity'], stageProps.weather.opacity, 'control')}
       />
     {/snippet}
   </FormControl>
@@ -90,6 +96,8 @@
         max={1}
         step={0.05}
         bind:value={stageProps.weather.intensity}
+        oninput={() =>
+          queuePropertyUpdate(stageProps, ['weather', 'intensity'], stageProps.weather.intensity, 'control')}
       />
     {/snippet}
   </FormControl>
@@ -107,8 +115,7 @@
         { label: 'off', value: 'false' }
       ]}
       onSelectedChange={(value) => {
-        stageProps.fog.enabled = value === 'true';
-        socketUpdate();
+        queuePropertyUpdate(stageProps, ['fog', 'enabled'], value === 'true', 'control');
       }}
     />
   </div>

--- a/apps/web/src/lib/components/GameSession/WeatherControls.svelte
+++ b/apps/web/src/lib/components/GameSession/WeatherControls.svelte
@@ -16,11 +16,9 @@
   import chroma from 'chroma-js';
 
   let {
-    socketUpdate,
     stageProps = $bindable(),
     errors
   }: {
-    socketUpdate: () => void;
     stageProps: StageProps;
     errors: ZodIssue[] | undefined;
   } = $props();

--- a/apps/web/src/lib/server/ws/index.ts
+++ b/apps/web/src/lib/server/ws/index.ts
@@ -1,4 +1,5 @@
 import { type BroadcastStageUpdate, type MarkerPositionUpdate } from '$lib/utils';
+import type { PropertyUpdates } from '$lib/utils/propertyUpdateBroadcaster';
 import { Server } from 'socket.io';
 
 // eslint-disable-next-line  @typescript-eslint/no-explicit-any
@@ -17,6 +18,12 @@ export const initializeSocketIO = (server: any) => {
     socket.on('markerPositionUpdate', (data: MarkerPositionUpdate) => {
       // Broadcast only the marker position data (much smaller payload)
       socket.nsp.emit('markerUpdated', data);
+    });
+
+    // Listen for optimized property updates
+    socket.on('propertyUpdates', (data: PropertyUpdates) => {
+      // Broadcast only the specific property updates (smaller payload)
+      socket.nsp.emit('propertiesUpdated', data);
     });
 
     // Listen for cursor movements

--- a/apps/web/src/lib/utils/index.ts
+++ b/apps/web/src/lib/utils/index.ts
@@ -13,6 +13,7 @@ export * from './handleStageZoom';
 export * from './hasThumb';
 export * from './isValidEmail';
 export * from './isWithinExpirationDate';
+export * from './propertyUpdateBroadcaster';
 export * from './randomQuotes';
 export * from './sceneSettings';
 export * from './stageKeyCommands';

--- a/apps/web/src/lib/utils/propertyUpdateBroadcaster.ts
+++ b/apps/web/src/lib/utils/propertyUpdateBroadcaster.ts
@@ -6,9 +6,9 @@ const pendingUpdates: Record<string, any> = {};
 let updateScheduled = false;
 
 // Different throttle times for different property types
-const MARKER_UPDATE_DELAY = 150; // Fast for marker positions
-const UI_CONTROL_DELAY = 250; // Medium for UI controls like opacity
-const SCENE_UPDATE_DELAY = 500; // Slow for major scene changes
+const MARKER_UPDATE_DELAY = 150;
+const UI_CONTROL_DELAY = 250;
+const SCENE_UPDATE_DELAY = 500;
 
 export type PropertyPath = string[];
 
@@ -64,7 +64,6 @@ function applyUpdate(obj: any, path: PropertyPath, value: any) {
     current = current[path[i]];
   }
 
-  // Update the property
   current[lastKey] = value;
 }
 
@@ -73,7 +72,6 @@ let pendingSocketUpdate: (() => void) | null = null;
 let socket: Socket | null = null;
 let sceneId: string | null = null;
 
-// Register socketUpdate function
 export function registerSocketUpdate(
   socketUpdateFn: () => void,
   socketInstance: Socket | null,

--- a/apps/web/src/lib/utils/propertyUpdateBroadcaster.ts
+++ b/apps/web/src/lib/utils/propertyUpdateBroadcaster.ts
@@ -1,0 +1,108 @@
+import type { StageProps } from '@tableslayer/ui';
+import type { Socket } from 'socket.io-client';
+
+// Track pending updates for different property paths
+const pendingUpdates: Record<string, any> = {};
+let updateScheduled = false;
+
+// Different throttle times for different property types
+const MARKER_UPDATE_DELAY = 150; // Fast for marker positions
+const UI_CONTROL_DELAY = 250; // Medium for UI controls like opacity
+const SCENE_UPDATE_DELAY = 500; // Slow for major scene changes
+
+export type PropertyPath = string[];
+
+// Update specific property and schedule broadcast
+export function queuePropertyUpdate(
+  stageProps: StageProps,
+  propertyPath: PropertyPath,
+  value: any,
+  updateType: 'marker' | 'control' | 'scene' = 'control'
+) {
+  // Update the property immediately in the local state
+  applyUpdate(stageProps, propertyPath, value);
+
+  // Store path and value for later batch update
+  const pathKey = propertyPath.join('.');
+  pendingUpdates[pathKey] = { path: propertyPath, value };
+
+  // Schedule batch update if not already scheduled
+  if (!updateScheduled) {
+    updateScheduled = true;
+
+    // Select throttle delay based on update type
+    const delay =
+      updateType === 'marker' ? MARKER_UPDATE_DELAY : updateType === 'scene' ? SCENE_UPDATE_DELAY : UI_CONTROL_DELAY;
+
+    setTimeout(() => {
+      // Make a copy of pending updates before clearing
+      const updates = { ...pendingUpdates };
+
+      // Clear pending updates and reset flag
+      Object.keys(pendingUpdates).forEach((key) => delete pendingUpdates[key]);
+      updateScheduled = false;
+
+      // Now broadcast the updates
+      if (pendingSocketUpdate && socket && sceneId) {
+        broadcastPropertyUpdates(socket, updates, sceneId);
+        pendingSocketUpdate();
+      }
+    }, delay);
+  }
+}
+
+// Helper to apply update at specific path
+function applyUpdate(obj: any, path: PropertyPath, value: any) {
+  const lastKey = path[path.length - 1];
+  let current = obj;
+
+  // Navigate to the parent object
+  for (let i = 0; i < path.length - 1; i++) {
+    if (current[path[i]] === undefined) {
+      current[path[i]] = {};
+    }
+    current = current[path[i]];
+  }
+
+  // Update the property
+  current[lastKey] = value;
+}
+
+// Store socket update function and socket when available
+let pendingSocketUpdate: (() => void) | null = null;
+let socket: Socket | null = null;
+let sceneId: string | null = null;
+
+// Register socketUpdate function
+export function registerSocketUpdate(
+  socketUpdateFn: () => void,
+  socketInstance: Socket | null,
+  currentSceneId: string
+) {
+  pendingSocketUpdate = socketUpdateFn;
+  socket = socketInstance;
+  sceneId = currentSceneId;
+}
+
+// Broadcast multiple property updates at once
+function broadcastPropertyUpdates(socket: Socket, updates: Record<string, any>, sceneId: string) {
+  if (!socket || !sceneId) return;
+
+  const updateData = {
+    properties: Object.values(updates),
+    sceneId
+  };
+
+  socket.emit('propertyUpdates', updateData);
+}
+
+export type PropertyUpdate = {
+  path: PropertyPath;
+  value: any;
+  sceneId: string;
+};
+
+export type PropertyUpdates = {
+  properties: Array<{ path: PropertyPath; value: any }>;
+  sceneId: string;
+};

--- a/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
+++ b/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
@@ -28,8 +28,7 @@
     convertStageMarkersToDbFormat,
     throttle,
     type MarkerPositionUpdate,
-    registerSocketUpdate,
-    queuePropertyUpdate
+    registerSocketUpdate
   } from '$lib/utils';
   import { onMount } from 'svelte';
 

--- a/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
+++ b/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
@@ -27,7 +27,9 @@
     convertPropsToSceneDetails,
     convertStageMarkersToDbFormat,
     throttle,
-    type MarkerPositionUpdate
+    type MarkerPositionUpdate,
+    registerSocketUpdate,
+    queuePropertyUpdate
   } from '$lib/utils';
   import { onMount } from 'svelte';
 
@@ -89,6 +91,13 @@
   const socketUpdate = () => {
     broadcastStageUpdate(socket, activeScene, selectedScene, stageProps, activeSceneMarkers, gameSession.isPaused);
   };
+
+  // Register the socketUpdate function with the property broadcaster
+  $effect(() => {
+    if (socket && selectedScene && selectedScene.id) {
+      registerSocketUpdate(socketUpdate, socket, selectedScene.id);
+    }
+  });
 
   /**
    * KEYBOARD HANDLER

--- a/apps/web/src/routes/(app)/[party]/[gameSession]/share/+page@.svelte
+++ b/apps/web/src/routes/(app)/[party]/[gameSession]/share/+page@.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte';
   import { setupGameSessionWebSocket, getRandomFantasyQuote, buildSceneProps } from '$lib/utils';
   import { MapLayerType, Stage, Text, Title, type StageExports, type StageProps, type Marker } from '@tableslayer/ui';
-  import type { BroadcastStageUpdate, MarkerPositionUpdate } from '$lib/utils';
+  import type { BroadcastStageUpdate, MarkerPositionUpdate, PropertyUpdates } from '$lib/utils';
   import { Head } from '$lib/components';
   import { StageDefaultProps } from '$lib/utils/defaultMapState';
 
@@ -115,12 +115,13 @@
     });
 
     // Handle optimized property updates
-    socket.on('propertiesUpdated', (updates) => {
+    socket.on('propertiesUpdated', (updates: PropertyUpdates) => {
       if (!updates || !updates.properties || updates.sceneId !== data.activeScene?.id) return;
 
       // Apply all property updates without rebuilding the entire state
       updates.properties.forEach((update) => {
-        let current = stageProps;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let current: any = stageProps;
         // Navigate to the parent object
         for (let i = 0; i < update.path.length - 1; i++) {
           if (!current[update.path[i]]) {


### PR DESCRIPTION
Related to https://github.com/Siege-Perilous/tableslayer/issues/261

Adds a new batch update system into the websocket layer. This attempts to do the following:
- Throttle updates based upon the type of update happens in stageProps. Markers update faster than UI...etc
- Only send the part of the stageProps that needs updating across the broadcast
- Batch updates that happen rapidly into a single update so stageProps isn't constantly changing

This removes the lag that would happen when you'd move the position of the markers. I have a feeling that previously the level of changes happening, could build and build over time leading to massive amounts of lag in the playfield.

This will need pretty heavy testing.
