### PR TITLE
Make ConfirmActionButton use floating-ui

### DIFF
--- a/packages/ui/src/lib/components/Button/ConfirmActionButton.svelte
+++ b/packages/ui/src/lib/components/Button/ConfirmActionButton.svelte
@@ -1,56 +1,97 @@
 <script lang="ts">
+  import { computePosition, offset, flip, shift, platform } from '@floating-ui/dom';
   import { Button, type ConfirmActionButtonProps } from './';
+  import { onDestroy, tick } from 'svelte';
+
   let {
     trigger,
     actionMessage,
     actionButtonText = 'Confirm delete',
     action,
     isLoading,
+    positioning = { placement: 'bottom' },
     ...restProps
   }: ConfirmActionButtonProps = $props();
 
+  let triggerElement: HTMLElement | null = null;
+  let popoverElement = $state<HTMLElement | null>(null);
   let isShowingConfirm = $state(false);
+  let floatingStyles = $state('');
 
-  const toggleShowConfirm = () => {
+  const toggleShowConfirm = async () => {
     isShowingConfirm = true;
+    await tick();
+    updatePosition();
   };
+
   const triggerProps = {
     onclick: () => {
       toggleShowConfirm();
     }
   };
+
+  function updatePosition() {
+    if (!triggerElement || !popoverElement) {
+      return;
+    }
+
+    computePosition(triggerElement, popoverElement, {
+      placement: positioning?.placement,
+      middleware: [offset(({ rects }) => -rects.reference.height / 2 - rects.floating.height / 2), flip(), shift()],
+      platform
+    })
+      .then(({ x, y, strategy }) => {
+        floatingStyles = `position: ${strategy}; left: ${x}px; top: ${y}px;`;
+      })
+      .catch((error) => {
+        console.error('Error in computePosition:', error);
+      });
+  }
+
+  const handleGlobalClick = (e: MouseEvent) => {
+    if (isShowingConfirm && popoverElement && triggerElement) {
+      const target = e.target as Node;
+      if (!popoverElement.contains(target) && !triggerElement.contains(target)) {
+        isShowingConfirm = false;
+      }
+    }
+  };
+
+  onDestroy(() => {
+    // Cleanup if needed
+  });
 </script>
 
-<div class="confirmAction" {...restProps}>
+<svelte:window onclick={handleGlobalClick} />
+
+<div class="confirmAction" bind:this={triggerElement} {...restProps}>
   {@render trigger({ triggerProps })}
-  {#if isShowingConfirm}
-    <div class="confirmAction__content">
-      {@render actionMessage()}
-      <div class="confirmAction__buttons">
-        <Button onclick={action} variant="danger" {isLoading}>
-          {actionButtonText}
-        </Button>
-        <Button onclick={() => (isShowingConfirm = false)} variant="ghost">Cancel</Button>
-      </div>
-    </div>
-  {/if}
 </div>
+
+{#if isShowingConfirm}
+  <div bind:this={popoverElement} class="confirmAction__content" style={floatingStyles}>
+    {@render actionMessage()}
+    <div class="confirmAction__buttons">
+      <Button onclick={action} variant="danger" {isLoading}>
+        {actionButtonText}
+      </Button>
+      <Button onclick={() => (isShowingConfirm = false)} variant="ghost">Cancel</Button>
+    </div>
+  </div>
+{/if}
 
 <style>
   .confirmAction {
-    position: relative;
     display: inline-flex;
     flex-direction: column;
     align-items: center;
   }
   .confirmAction__content {
-    position: absolute;
-    transform: translate(0%, -50%);
     background-color: var(--popoverBg);
     border-radius: var(--radius-2);
     box-shadow: var(--shadow-1);
     padding: 1rem;
-    z-index: 2;
+    z-index: 1000;
     border: var(--borderThin);
   }
   .confirmAction__buttons {

--- a/packages/ui/src/lib/components/Button/types.ts
+++ b/packages/ui/src/lib/components/Button/types.ts
@@ -1,3 +1,4 @@
+import type { FloatingConfig } from '@melt-ui/svelte/internal/actions';
 import type { Snippet } from 'svelte';
 import type { HTMLAnchorAttributes, HTMLButtonAttributes, SvelteHTMLElements } from 'svelte/elements';
 
@@ -41,6 +42,7 @@ export type ConfirmActionButtonProps = {
   action: (e: Event) => void;
   actionButtonText?: string;
   isLoading?: boolean;
+  positioning?: FloatingConfig;
 };
 
 export type RadioOption = { label: string | Snippet; value: string };


### PR DESCRIPTION
Fixes https://github.com/Siege-Perilous/tableslayer/issues/262

- Use floating-ui library to position popover, which uses a portal by default
- Use offset trick to center positioning above the trigger https://github.com/floating-ui/floating-ui/issues/1769#issuecomment-1178592672

![image](https://github.com/user-attachments/assets/5e1cbc81-0026-4e5c-b533-4098c43c2247)
