### PR TITLE
Pin Three JS to 174 for now

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,7 @@ jobs:
       FLY_REGION: ${{ secrets.FLY_REGION }}
       FLY_ORG: ${{ secrets.FLY_ORG }}
       TURSO_APP_DB_URL: ${{ needs.create_database.outputs.turso_db_url }}
+      NODE_OPTIONS: '--max-old-space-size=4096'
 
     # Only run one deployment at a time per PR.
     concurrency:
@@ -247,6 +248,8 @@ jobs:
           #  secrets: TURSO_API_TOKEN=${{ secrets.TURSO_API_TOKEN }} TURSO_APP_DB_AUTH_TOKEN=${{ secrets.TURSO_APP_DB_AUTH_TOKEN }} TURSO_APP_DB_URL=${{ needs.create_database.outputs.turso_db_url }} TURSO_GS_PARENT_DB_URL=${{ secrets.TURSO_GS_PARENT_DB_URL }} TURSO_GS_PARENT_DB_AUTH_TOKEN=${{ secrets.TURSO_GS_PARENT_DB_AUTH_TOKEN }} RESEND_TOKEN=${{ secrets.RESEND_TOKEN }} CLOUDFLARE_ACCOUNT_ID=${{ secrets.CLOUDFLARE_ACCOUNT_ID }} CLOUDFLARE_R2_ACCESS_KEY=${{ secrets.CLOUDFLARE_R2_ACCESS_KEY }} CLOUDFLARE_R2_SECRET_KEY=${{ secrets.CLOUDFLARE_R2_SECRET_KEY }} CLOUDFLARE_R2_BUCKET_NAME=${{ secrets.CLOUDFLARE_R2_BUCKET_NAME }} ENV_NAME=preview BASE_URL=${{ steps.deploy.outputs.url }} GITHUB_PR_NUMBER=${{ github.event.pull_request.number }}
           name: pr-${{ github.event.pull_request.number }}-web
           config: fly.dev.toml
+        env:
+          NODE_OPTIONS: '--max-old-space-size=4096'
       - name: Update PR Comment After Web Deployment
         uses: peter-evans/create-or-update-comment@v3
         with:

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -34,18 +34,6 @@
 </Panel>
 
 <style>
-  :global(.title.heroTitle) {
-    font-size: 4rem;
-    line-height: 1.2;
-    font-weight: 900;
-    width: fit-content;
-    /*  color: transparent;  */
-    /*  background-clip: text;  */
-    /*  background-image: linear-gradient(0deg, rgba(122, 5, 5, 1) 0%, rgba(223, 5, 5, 1) 35%, rgba(255, 0, 50, 1) 100%);  */
-    /*  text-shadow:  */
-    /*  2px 2px 0 rgba(255, 255, 255, 0.2),  */
-    /*  -1px 0 0 rgba(255, 255, 255, 1);  */
-  }
   :global {
     .panel.panel--home {
       display: flex;
@@ -64,14 +52,6 @@
       color: var(--fg);
     }
   }
-  .flex {
-    display: flex;
-    gap: var(--size-4);
-  }
-  :global(.heroTitle) {
-    letter-spacing: 0.2rem;
-  }
-
   @media (max-width: 768px) {
     :global(.panel.panel--home) {
       margin: 3rem 3rem auto 3rem;

--- a/fly.dev.toml
+++ b/fly.dev.toml
@@ -12,6 +12,7 @@ primary_region = 'ewr'
 [env]
   PORT = '8080'
   BODY_SIZE_LIMIT = "20M"
+  NODE_OPTIONS = "--max-old-space-size=4096"
 
 [http_service]
   internal_port = 8080
@@ -22,6 +23,6 @@ primary_region = 'ewr'
   processes = ['app']
 
 [[vm]]
-  memory = '1gb'
+  memory = '2gb'
   cpu_kind = 'shared'
   cpus = 1

--- a/fly.dev.toml
+++ b/fly.dev.toml
@@ -12,7 +12,6 @@ primary_region = 'ewr'
 [env]
   PORT = '8080'
   BODY_SIZE_LIMIT = "20M"
-  NODE_OPTIONS = "--max-old-space-size=4096"
 
 [http_service]
   internal_port = 8080
@@ -23,6 +22,6 @@ primary_region = 'ewr'
   processes = ['app']
 
 [[vm]]
-  memory = '2gb'
+  memory = '1gb'
   cpu_kind = 'shared'
   cpus = 1

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -50,7 +50,7 @@
     "@tableslayer/tsconfig": "workspace:*",
     "@types/chroma-js": "^3.1.1",
     "@types/marked": "^6.0.0",
-    "@types/three": "0.175.0",
+    "@types/three": "0.174.0",
     "marked": "^15.0.7",
     "svelte": "5.25.3",
     "svelte-check": "^4.1.5",
@@ -72,7 +72,7 @@
     "class-variance-authority": "^0.7.1",
     "postprocessing": "6.37.2",
     "shiki": "^3.2.1",
-    "three": "0.175.0",
+    "three": "0.174.0",
     "zod": "^3.24.2"
   },
   "svelte": "./src/lib/index.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -50,7 +50,7 @@
     "@tableslayer/tsconfig": "workspace:*",
     "@types/chroma-js": "^3.1.1",
     "@types/marked": "^6.0.0",
-    "@types/three": "0.174.0",
+    "@types/three": "=0.174.0",
     "marked": "^15.0.7",
     "svelte": "5.25.3",
     "svelte-check": "^4.1.5",
@@ -72,7 +72,7 @@
     "class-variance-authority": "^0.7.1",
     "postprocessing": "6.37.2",
     "shiki": "^3.2.1",
-    "three": "0.174.0",
+    "three": "=0.174.0",
     "zod": "^3.24.2"
   },
   "svelte": "./src/lib/index.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -311,7 +311,7 @@ importers:
         specifier: ^3.2.1
         version: 3.2.1
       three:
-        specifier: 0.174.0
+        specifier: '=0.174.0'
         version: 0.174.0
       zod:
         specifier: ^3.24.2
@@ -351,7 +351,7 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       '@types/three':
-        specifier: 0.174.0
+        specifier: '=0.174.0'
         version: 0.174.0
       marked:
         specifier: ^15.0.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,10 +279,10 @@ importers:
         version: 3.31.0(svelte@5.25.3)
       '@threlte/core':
         specifier: 8.0.1
-        version: 8.0.1(svelte@5.25.3)(three@0.175.0)
+        version: 8.0.1(svelte@5.25.3)(three@0.174.0)
       '@threlte/extras':
         specifier: 9.1.0
-        version: 9.1.0(@types/three@0.175.0)(svelte@5.25.3)(three@0.175.0)
+        version: 9.1.0(@types/three@0.174.0)(svelte@5.25.3)(three@0.174.0)
       '@tiptap/core':
         specifier: ^2.11.7
         version: 2.11.7(@tiptap/pm@2.11.7)
@@ -306,13 +306,13 @@ importers:
         version: 0.7.1
       postprocessing:
         specifier: 6.37.2
-        version: 6.37.2(three@0.175.0)
+        version: 6.37.2(three@0.174.0)
       shiki:
         specifier: ^3.2.1
         version: 3.2.1
       three:
-        specifier: 0.175.0
-        version: 0.175.0
+        specifier: 0.174.0
+        version: 0.174.0
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -351,8 +351,8 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       '@types/three':
-        specifier: 0.175.0
-        version: 0.175.0
+        specifier: 0.174.0
+        version: 0.174.0
       marked:
         specifier: ^15.0.7
         version: 15.0.7
@@ -2677,6 +2677,9 @@ packages:
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
+  '@types/three@0.174.0':
+    resolution: {integrity: sha512-De/+vZnfg2aVWNiuy1Ldu+n2ydgw1osinmiZTAn0necE++eOfsygL8JpZgFjR2uHmAPo89MkxBj3JJ+2BMe+Uw==}
+
   '@types/three@0.175.0':
     resolution: {integrity: sha512-ldMSBgtZOZ3g9kJ3kOZSEtZIEITmJOzu8eKVpkhf036GuNkM4mt0NXecrjCn5tMm1OblOF7dZehlaDypBfNokw==}
 
@@ -4670,6 +4673,9 @@ packages:
     resolution: {integrity: sha512-PtdBqtPZbXoQgxXAla393iPs+ox0HbZVKqA1ym3w4z7Og0Ihevg/odxjEYA9R6xwtIqS5qgsz8RyK3z8lFHtpQ==}
     peerDependencies:
       three: '>=0.162.0 <1.0.0'
+
+  three@0.174.0:
+    resolution: {integrity: sha512-p+WG3W6Ov74alh3geCMkGK9NWuT62ee21cV3jEnun201zodVF4tCE5aZa2U122/mkLRmhJJUQmLLW1BH00uQJQ==}
 
   three@0.175.0:
     resolution: {integrity: sha512-nNE3pnTHxXN/Phw768u0Grr7W4+rumGg/H6PgeseNJojkJtmeHJfZWi41Gp2mpXl1pg1pf1zjwR4McM1jTqkpg==}
@@ -7520,6 +7526,17 @@ snapshots:
       '@tanstack/query-core': 5.71.0
       svelte: 5.25.3
 
+  '@threejs-kit/instanced-sprite-mesh@2.5.0(@types/three@0.174.0)(three@0.174.0)':
+    dependencies:
+      diet-sprite: 0.0.1
+      earcut: 2.2.4
+      maath: 0.10.8(@types/three@0.174.0)(three@0.174.0)
+      three: 0.174.0
+      three-instanced-uniforms-mesh: 0.52.0(three@0.174.0)
+      troika-three-utils: 0.52.0(three@0.174.0)
+    transitivePeerDependencies:
+      - '@types/three'
+
   '@threejs-kit/instanced-sprite-mesh@2.5.0(@types/three@0.175.0)(three@0.175.0)':
     dependencies:
       diet-sprite: 0.0.1
@@ -7531,11 +7548,30 @@ snapshots:
     transitivePeerDependencies:
       - '@types/three'
 
+  '@threlte/core@8.0.1(svelte@5.25.3)(three@0.174.0)':
+    dependencies:
+      mitt: 3.0.1
+      svelte: 5.25.3
+      three: 0.174.0
+
   '@threlte/core@8.0.1(svelte@5.25.3)(three@0.175.0)':
     dependencies:
       mitt: 3.0.1
       svelte: 5.25.3
       three: 0.175.0
+
+  '@threlte/extras@9.1.0(@types/three@0.174.0)(svelte@5.25.3)(three@0.174.0)':
+    dependencies:
+      '@threejs-kit/instanced-sprite-mesh': 2.5.0(@types/three@0.174.0)(three@0.174.0)
+      camera-controls: 2.9.0(three@0.174.0)
+      svelte: 5.25.3
+      three: 0.174.0
+      three-mesh-bvh: 0.7.6(three@0.174.0)
+      three-perf: https://codeload.github.com/jerzakm/three-perf/tar.gz/322d7d38a17069f2b6e9734913edad0fc4a29169(three@0.174.0)
+      three-viewport-gizmo: 2.0.2(three@0.174.0)
+      troika-three-text: 0.50.3(three@0.174.0)
+    transitivePeerDependencies:
+      - '@types/three'
 
   '@threlte/extras@9.1.0(@types/three@0.175.0)(svelte@5.25.3)(three@0.175.0)':
     dependencies:
@@ -7781,6 +7817,15 @@ snapshots:
   '@types/tedious@4.0.14':
     dependencies:
       '@types/node': 22.9.1
+
+  '@types/three@0.174.0':
+    dependencies:
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.3
+      '@types/webxr': 0.5.20
+      '@webgpu/types': 0.1.51
+      fflate: 0.8.2
+      meshoptimizer: 0.18.1
 
   '@types/three@0.175.0':
     dependencies:
@@ -8090,6 +8135,10 @@ snapshots:
       get-intrinsic: 1.2.7
 
   callsites@3.1.0: {}
+
+  camera-controls@2.9.0(three@0.174.0):
+    dependencies:
+      three: 0.174.0
 
   camera-controls@2.9.0(three@0.175.0):
     dependencies:
@@ -9011,6 +9060,11 @@ snapshots:
 
   lunr@2.3.9: {}
 
+  maath@0.10.8(@types/three@0.174.0)(three@0.174.0):
+    dependencies:
+      '@types/three': 0.174.0
+      three: 0.174.0
+
   maath@0.10.8(@types/three@0.175.0)(three@0.175.0):
     dependencies:
       '@types/three': 0.175.0
@@ -9342,6 +9396,10 @@ snapshots:
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+
+  postprocessing@6.37.2(three@0.174.0):
+    dependencies:
+      three: 0.174.0
 
   postprocessing@6.37.2(three@0.175.0):
     dependencies:
@@ -9928,14 +9986,29 @@ snapshots:
       mkdirp: 3.0.1
       yallist: 5.0.0
 
+  three-instanced-uniforms-mesh@0.52.0(three@0.174.0):
+    dependencies:
+      three: 0.174.0
+      troika-three-utils: 0.52.0(three@0.174.0)
+
   three-instanced-uniforms-mesh@0.52.0(three@0.175.0):
     dependencies:
       three: 0.175.0
       troika-three-utils: 0.52.0(three@0.175.0)
 
+  three-mesh-bvh@0.7.6(three@0.174.0):
+    dependencies:
+      three: 0.174.0
+
   three-mesh-bvh@0.7.6(three@0.175.0):
     dependencies:
       three: 0.175.0
+
+  three-perf@https://codeload.github.com/jerzakm/three-perf/tar.gz/322d7d38a17069f2b6e9734913edad0fc4a29169(three@0.174.0):
+    dependencies:
+      three: 0.174.0
+      troika-three-text: 0.52.3(three@0.174.0)
+      tweakpane: 3.1.10
 
   three-perf@https://codeload.github.com/jerzakm/three-perf/tar.gz/322d7d38a17069f2b6e9734913edad0fc4a29169(three@0.175.0):
     dependencies:
@@ -9943,9 +10016,15 @@ snapshots:
       troika-three-text: 0.52.3(three@0.175.0)
       tweakpane: 3.1.10
 
+  three-viewport-gizmo@2.0.2(three@0.174.0):
+    dependencies:
+      three: 0.174.0
+
   three-viewport-gizmo@2.0.2(three@0.175.0):
     dependencies:
       three: 0.175.0
+
+  three@0.174.0: {}
 
   three@0.175.0: {}
 
@@ -9976,12 +10055,28 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
+  troika-three-text@0.50.3(three@0.174.0):
+    dependencies:
+      bidi-js: 1.0.3
+      three: 0.174.0
+      troika-three-utils: 0.50.3(three@0.174.0)
+      troika-worker-utils: 0.50.0
+      webgl-sdf-generator: 1.1.1
+
   troika-three-text@0.50.3(three@0.175.0):
     dependencies:
       bidi-js: 1.0.3
       three: 0.175.0
       troika-three-utils: 0.50.3(three@0.175.0)
       troika-worker-utils: 0.50.0
+      webgl-sdf-generator: 1.1.1
+
+  troika-three-text@0.52.3(three@0.174.0):
+    dependencies:
+      bidi-js: 1.0.3
+      three: 0.174.0
+      troika-three-utils: 0.52.0(three@0.174.0)
+      troika-worker-utils: 0.52.0
       webgl-sdf-generator: 1.1.1
 
   troika-three-text@0.52.3(three@0.175.0):
@@ -9992,9 +10087,17 @@ snapshots:
       troika-worker-utils: 0.52.0
       webgl-sdf-generator: 1.1.1
 
+  troika-three-utils@0.50.3(three@0.174.0):
+    dependencies:
+      three: 0.174.0
+
   troika-three-utils@0.50.3(three@0.175.0):
     dependencies:
       three: 0.175.0
+
+  troika-three-utils@0.52.0(three@0.174.0):
+    dependencies:
+      three: 0.174.0
 
   troika-three-utils@0.52.0(three@0.175.0):
     dependencies:


### PR DESCRIPTION
The deps update on Monday moved Three JS to 175. For some reason this caused the Stage docs not to load. It didn't seem to change the app version. I'm going to revert back for a bit so I can get users testing the docs layer to see if we have the same memory issues in the docs.

![image](https://github.com/user-attachments/assets/928242a1-9701-404b-9f91-8c4447302f38)
