### PR TITLE
Add proper disposal of texture and geometry resources

### DIFF
--- a/apps/docs/src/routes/(components)/stage/defaults.ts
+++ b/apps/docs/src/routes/(components)/stage/defaults.ts
@@ -17,7 +17,7 @@ export const StageDefaultProps: StageProps = {
   activeLayer: MapLayerType.None,
   backgroundColor: '#404040',
   debug: {
-    enableStats: true,
+    enableStats: false,
     loggingRate: 30
   },
   display: {

--- a/packages/ui/src/lib/components/Stage/components/EdgeOverlayLayer/EdgeOverlayLayer.svelte
+++ b/packages/ui/src/lib/components/Stage/components/EdgeOverlayLayer/EdgeOverlayLayer.svelte
@@ -30,6 +30,7 @@
         }
       })
       .then((tex) => {
+        texture?.dispose();
         texture = tex;
       });
   });

--- a/packages/ui/src/lib/components/Stage/components/FogOfWarLayer/FogOfWarMaterial.svelte
+++ b/packages/ui/src/lib/components/Stage/components/FogOfWarLayer/FogOfWarMaterial.svelte
@@ -226,7 +226,6 @@
 
     if (persist) {
       swapBuffers();
-      lastTexture?.dispose();
     }
   }
 

--- a/packages/ui/src/lib/components/Stage/components/FogOfWarLayer/FogOfWarMaterial.svelte
+++ b/packages/ui/src/lib/components/Stage/components/FogOfWarLayer/FogOfWarMaterial.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import * as THREE from 'three';
-  import { T, useTask, useThrelte } from '@threlte/core';
+  import { T, useTask, useThrelte, useLoader } from '@threlte/core';
   import { DrawMode, type FogOfWarLayerProps } from './types';
   import { onDestroy, untrack } from 'svelte';
   import type { Size } from '../../types';
@@ -84,8 +84,8 @@
   };
 
   let imageUrl: string | null = $state(null);
-  const textureLoader = new THREE.TextureLoader();
 
+  const loader = useLoader(THREE.TextureLoader);
   // Double-buffered render targets
   let tempTarget = new THREE.WebGLRenderTarget(1, 1, options);
   let persistedTarget = new THREE.WebGLRenderTarget(1, 1, options);
@@ -180,7 +180,7 @@
   });
 
   function loadImage(url: string) {
-    textureLoader.load(url, (texture) => render('revert', true, texture));
+    loader.load(url).then((texture) => render('revert', true, texture));
   }
 
   /**
@@ -226,6 +226,7 @@
 
     if (persist) {
       swapBuffers();
+      lastTexture?.dispose();
     }
   }
 

--- a/packages/ui/src/lib/components/Stage/components/MapLayer/MapLayer.svelte
+++ b/packages/ui/src/lib/components/Stage/components/MapLayer/MapLayer.svelte
@@ -22,6 +22,7 @@
   const callbacks = getContext<Callbacks>('callbacks');
   const onMapUpdate = callbacks.onMapUpdate;
 
+  const loader = useLoader(TextureLoader);
   let imageUrl: string | null = $state(null);
   let mapImageMaterial = new THREE.MeshBasicMaterial();
   let fogOfWarLayer: FogOfWarExports;
@@ -49,7 +50,7 @@
     onMapLoading();
 
     // Update the image whenever the URL is changed
-    useLoader(TextureLoader)
+    loader
       .load(props.map.url, {
         transform: (texture) => {
           texture.colorSpace = THREE.SRGBColorSpace;

--- a/packages/ui/src/lib/components/Stage/components/MapLayer/MapLayer.svelte
+++ b/packages/ui/src/lib/components/Stage/components/MapLayer/MapLayer.svelte
@@ -19,8 +19,6 @@
 
   const { props, onMapLoading, onMapLoaded }: Props = $props();
 
-  const loader = useLoader(TextureLoader);
-
   const callbacks = getContext<Callbacks>('callbacks');
   const onMapUpdate = callbacks.onMapUpdate;
 
@@ -51,7 +49,7 @@
     onMapLoading();
 
     // Update the image whenever the URL is changed
-    loader
+    useLoader(TextureLoader)
       .load(props.map.url, {
         transform: (texture) => {
           texture.colorSpace = THREE.SRGBColorSpace;
@@ -59,6 +57,7 @@
         }
       })
       .then((texture) => {
+        mapImageMaterial.map?.dispose();
         mapImageMaterial.map = texture;
         mapImageMaterial.needsUpdate = true;
         mapSize = {
@@ -78,6 +77,7 @@
   }
 
   export function getCompositeMapTexture(): THREE.Texture | null {
+    console.log('getCompositeMapTexture', mapImageMaterial.map);
     return mapImageMaterial.map;
   }
 

--- a/packages/ui/src/lib/components/Stage/components/MapLayer/MapLayer.svelte
+++ b/packages/ui/src/lib/components/Stage/components/MapLayer/MapLayer.svelte
@@ -77,7 +77,6 @@
   }
 
   export function getCompositeMapTexture(): THREE.Texture | null {
-    console.log('getCompositeMapTexture', mapImageMaterial.map);
     return mapImageMaterial.map;
   }
 

--- a/packages/ui/src/lib/components/Stage/components/MarkerLayer/MarkerToken.svelte
+++ b/packages/ui/src/lib/components/Stage/components/MarkerLayer/MarkerToken.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import * as THREE from 'three';
-  import { T } from '@threlte/core';
+  import { T, useLoader } from '@threlte/core';
   import { MarkerShape, type Marker } from './types';
   import { SceneLayer, SceneLayerOrder } from '../Scene/types';
   import { getGridCellSize } from '../../helpers/grid';
@@ -43,6 +43,7 @@
     shadowOffset
   }: Props = $props();
 
+  const loader = useLoader(THREE.TextureLoader);
   const markerSize = $derived(getGridCellSize(grid, display) * marker.size);
 
   // The size of the marker is 90% of the grid cell size
@@ -63,16 +64,13 @@
   // Load image if URL is provided
   $effect(() => {
     if (marker.imageUrl) {
-      const loader = new THREE.TextureLoader();
-      loader.load(
-        marker.imageUrl,
-        (texture) => {
+      loader
+        .load(marker.imageUrl)
+        .then((texture) => {
           imageTexture = texture;
           imageTexture.needsUpdate = true;
-        },
-        undefined,
-        (err) => console.error('Error loading image:', err)
-      );
+        })
+        .catch((err) => console.error('Error loading image:', err));
     } else {
       imageTexture = null;
     }

--- a/packages/ui/src/lib/components/Stage/components/ParticleSystem/ParticleSystem.svelte
+++ b/packages/ui/src/lib/components/Stage/components/ParticleSystem/ParticleSystem.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import * as THREE from 'three';
-  import { T, useTask } from '@threlte/core';
+  import { T, useTask, useLoader } from '@threlte/core';
   import { ParticleData } from './types';
   import type { ParticleSystemProps } from './types';
   import { RNG } from './rng';
@@ -8,6 +8,7 @@
   import fragmentShader from '../../shaders/Particles.frag?raw';
   import vertexShader from '../../shaders/Particles.vert?raw';
   import { DEG2RAD } from 'three/src/math/MathUtils';
+  import { onDestroy, untrack } from 'svelte';
 
   interface Props {
     props: ParticleSystemProps;
@@ -18,142 +19,155 @@
   const { props, opacity, intensity }: Props = $props();
 
   let mesh: THREE.Mesh | undefined = $state(undefined);
+  let geometry: THREE.BufferGeometry | undefined = $state(undefined);
 
-  const geometry = $derived.by(() => {
-    const geometry = new THREE.BufferGeometry();
+  $effect(() => {
+    untrack(() => {
+      geometry?.dispose();
 
-    const rng = new RNG(0);
-    const count = Math.round(props.maxParticleCount * (intensity ?? 1));
+      geometry = new THREE.BufferGeometry();
 
-    // Initialize particle attributes - 4 vertices per quad
-    const positions = new Float32Array(count * 12); // 4 vertices * 3 coords
-    const centers = new Float32Array(count * 8); // 1 center * 2 coords
-    const uvs = new Float32Array(count * 8); // 4 vertices * 2 coords
-    const indices = new Uint32Array(count * 6); // 2 triangles * 3 vertices
-    const ageOffsets = new Float32Array(count * 4); // 4 vertices
+      const rng = new RNG(0);
+      const count = Math.round(props.maxParticleCount * (intensity ?? 1));
 
-    const particle = ParticleData[props.type];
+      // Initialize particle attributes - 4 vertices per quad
+      const positions = new Float32Array(count * 12); // 4 vertices * 3 coords
+      const centers = new Float32Array(count * 8); // 1 center * 2 coords
+      const uvs = new Float32Array(count * 8); // 4 vertices * 2 coords
+      const indices = new Uint32Array(count * 6); // 2 triangles * 3 vertices
+      const ageOffsets = new Float32Array(count * 4); // 4 vertices
 
-    // Initialize particles
-    for (let i = 0; i < count; i++) {
-      const radius = rng.random() * (props.spawnArea.maxRadius - props.spawnArea.minRadius) + props.spawnArea.minRadius;
-      const angle = rng.random() * 2 * Math.PI;
-      const x = radius * Math.cos(angle);
-      const y = radius * Math.sin(angle);
-      const z = -1.001;
+      const particle = ParticleData[props.type];
 
-      // Quad vertex positions (same for all 4 corners initially)
-      const baseIdx = i * 12;
+      // Initialize particles
+      for (let i = 0; i < count; i++) {
+        const radius =
+          rng.random() * (props.spawnArea.maxRadius - props.spawnArea.minRadius) + props.spawnArea.minRadius;
+        const angle = rng.random() * 2 * Math.PI;
+        const x = radius * Math.cos(angle);
+        const y = radius * Math.sin(angle);
+        const z = -1.001;
 
-      // Generate random size for this particle
-      let size = rng.random() * (props.size.max - props.size.min) + props.size.min;
-      let width = size * props.scale.x;
-      let height = size * props.scale.y;
+        // Quad vertex positions (same for all 4 corners initially)
+        const baseIdx = i * 12;
 
-      const rotation = new THREE.Euler(0, 0, props.rotation.offset * DEG2RAD);
-      rotation.z += props.rotation.alignRadially ? angle : 0;
-      rotation.z += props.rotation.randomize ? rng.random() * 360 : 0;
+        // Generate random size for this particle
+        let size = rng.random() * (props.size.max - props.size.min) + props.size.min;
+        let width = size * props.scale.x;
+        let height = size * props.scale.y;
 
-      const v1 = new THREE.Vector3(-width / 2, -height / 2, 0);
-      const v2 = new THREE.Vector3(width / 2, -height / 2, 0);
-      const v3 = new THREE.Vector3(-width / 2, height / 2, 0);
-      const v4 = new THREE.Vector3(width / 2, height / 2, 0);
+        const rotation = new THREE.Euler(0, 0, props.rotation.offset * DEG2RAD);
+        rotation.z += props.rotation.alignRadially ? angle : 0;
+        rotation.z += props.rotation.randomize ? rng.random() * 360 : 0;
 
-      v1.applyEuler(rotation);
-      v2.applyEuler(rotation);
-      v3.applyEuler(rotation);
-      v4.applyEuler(rotation);
+        const v1 = new THREE.Vector3(-width / 2, -height / 2, 0);
+        const v2 = new THREE.Vector3(width / 2, -height / 2, 0);
+        const v3 = new THREE.Vector3(-width / 2, height / 2, 0);
+        const v4 = new THREE.Vector3(width / 2, height / 2, 0);
 
-      v1.add(new THREE.Vector3(x, y, z));
-      v2.add(new THREE.Vector3(x, y, z));
-      v3.add(new THREE.Vector3(x, y, z));
-      v4.add(new THREE.Vector3(x, y, z));
+        v1.applyEuler(rotation);
+        v2.applyEuler(rotation);
+        v3.applyEuler(rotation);
+        v4.applyEuler(rotation);
 
-      // Set quad corners with size offset
-      positions[baseIdx] = v1.x; // Bottom left x
-      positions[baseIdx + 1] = v1.y; // Bottom left y
-      positions[baseIdx + 2] = v1.z; // Bottom left z
+        v1.add(new THREE.Vector3(x, y, z));
+        v2.add(new THREE.Vector3(x, y, z));
+        v3.add(new THREE.Vector3(x, y, z));
+        v4.add(new THREE.Vector3(x, y, z));
 
-      positions[baseIdx + 3] = v2.x; // Bottom right x
-      positions[baseIdx + 4] = v2.y; // Bottom right y
-      positions[baseIdx + 5] = v2.z; // Bottom right z
+        // Set quad corners with size offset
+        positions[baseIdx] = v1.x; // Bottom left x
+        positions[baseIdx + 1] = v1.y; // Bottom left y
+        positions[baseIdx + 2] = v1.z; // Bottom left z
 
-      positions[baseIdx + 6] = v3.x; // Top left x
-      positions[baseIdx + 7] = v3.y; // Top left y
-      positions[baseIdx + 8] = v3.z; // Top left z
+        positions[baseIdx + 3] = v2.x; // Bottom right x
+        positions[baseIdx + 4] = v2.y; // Bottom right y
+        positions[baseIdx + 5] = v2.z; // Bottom right z
 
-      positions[baseIdx + 9] = v4.x; // Top right x
-      positions[baseIdx + 10] = v4.y; // Top right y
-      positions[baseIdx + 11] = v4.z; // Top right z
+        positions[baseIdx + 6] = v3.x; // Top left x
+        positions[baseIdx + 7] = v3.y; // Top left y
+        positions[baseIdx + 8] = v3.z; // Top left z
 
-      // Set center position
-      const centerIdx = i * 8;
-      centers[centerIdx] = x;
-      centers[centerIdx + 1] = y;
-      centers[centerIdx + 2] = x;
-      centers[centerIdx + 3] = y;
-      centers[centerIdx + 4] = x;
-      centers[centerIdx + 5] = y;
-      centers[centerIdx + 6] = x;
-      centers[centerIdx + 7] = y;
+        positions[baseIdx + 9] = v4.x; // Top right x
+        positions[baseIdx + 10] = v4.y; // Top right y
+        positions[baseIdx + 11] = v4.z; // Top right z
 
-      // Calculate random frame from texture atlas
-      const frame = Math.floor(rng.random() * (particle.columns * particle.rows));
-      const col = frame % particle.columns;
-      const row = Math.floor(frame / particle.columns);
+        // Set center position
+        const centerIdx = i * 8;
+        centers[centerIdx] = x;
+        centers[centerIdx + 1] = y;
+        centers[centerIdx + 2] = x;
+        centers[centerIdx + 3] = y;
+        centers[centerIdx + 4] = x;
+        centers[centerIdx + 5] = y;
+        centers[centerIdx + 6] = x;
+        centers[centerIdx + 7] = y;
 
-      // Calculate UV coordinates for this frame
-      const uv0 = new THREE.Vector2(col / particle.columns, row / particle.rows);
-      const uv1 = new THREE.Vector2((col + 1) / particle.columns, (row + 1) / particle.rows);
+        // Calculate random frame from texture atlas
+        const frame = Math.floor(rng.random() * (particle.columns * particle.rows));
+        const col = frame % particle.columns;
+        const row = Math.floor(frame / particle.columns);
 
-      // UV coordinates for quad
-      const uvBaseIdx = i * 8;
-      uvs[uvBaseIdx] = uv0.x; // bottom left
-      uvs[uvBaseIdx + 1] = uv0.y;
-      uvs[uvBaseIdx + 2] = uv1.x; // bottom right
-      uvs[uvBaseIdx + 3] = uv0.y;
-      uvs[uvBaseIdx + 4] = uv0.x; // top left
-      uvs[uvBaseIdx + 5] = uv1.y;
-      uvs[uvBaseIdx + 6] = uv1.x; // top right
-      uvs[uvBaseIdx + 7] = uv1.y;
+        // Calculate UV coordinates for this frame
+        const uv0 = new THREE.Vector2(col / particle.columns, row / particle.rows);
+        const uv1 = new THREE.Vector2((col + 1) / particle.columns, (row + 1) / particle.rows);
 
-      // Indices for two triangles
-      const indexBaseIdx = i * 6;
-      const vertexBaseIdx = i * 4;
-      indices[indexBaseIdx] = vertexBaseIdx;
-      indices[indexBaseIdx + 1] = vertexBaseIdx + 1;
-      indices[indexBaseIdx + 2] = vertexBaseIdx + 2;
-      indices[indexBaseIdx + 3] = vertexBaseIdx + 1;
-      indices[indexBaseIdx + 4] = vertexBaseIdx + 3;
-      indices[indexBaseIdx + 5] = vertexBaseIdx + 2;
+        // UV coordinates for quad
+        const uvBaseIdx = i * 8;
+        uvs[uvBaseIdx] = uv0.x; // bottom left
+        uvs[uvBaseIdx + 1] = uv0.y;
+        uvs[uvBaseIdx + 2] = uv1.x; // bottom right
+        uvs[uvBaseIdx + 3] = uv0.y;
+        uvs[uvBaseIdx + 4] = uv0.x; // top left
+        uvs[uvBaseIdx + 5] = uv1.y;
+        uvs[uvBaseIdx + 6] = uv1.x; // top right
+        uvs[uvBaseIdx + 7] = uv1.y;
 
-      // Random attributes (same for all vertices of quad)
-      const ageOffset = rng.random() * props.lifetime;
+        // Indices for two triangles
+        const indexBaseIdx = i * 6;
+        const vertexBaseIdx = i * 4;
+        indices[indexBaseIdx] = vertexBaseIdx;
+        indices[indexBaseIdx + 1] = vertexBaseIdx + 1;
+        indices[indexBaseIdx + 2] = vertexBaseIdx + 2;
+        indices[indexBaseIdx + 3] = vertexBaseIdx + 1;
+        indices[indexBaseIdx + 4] = vertexBaseIdx + 3;
+        indices[indexBaseIdx + 5] = vertexBaseIdx + 2;
 
-      for (let v = 0; v < 4; v++) {
-        ageOffsets[i * 4 + v] = ageOffset;
+        // Random attributes (same for all vertices of quad)
+        const ageOffset = rng.random() * props.lifetime;
+
+        for (let v = 0; v < 4; v++) {
+          ageOffsets[i * 4 + v] = ageOffset;
+        }
       }
-    }
 
-    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
-    geometry.setAttribute('center', new THREE.BufferAttribute(centers, 2));
-    geometry.setAttribute('uv', new THREE.BufferAttribute(uvs, 2));
-    geometry.setAttribute('ageOffset', new THREE.BufferAttribute(ageOffsets, 1));
-    geometry.setIndex(new THREE.BufferAttribute(indices, 1));
-
-    return geometry;
+      geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+      geometry.setAttribute('center', new THREE.BufferAttribute(centers, 2));
+      geometry.setAttribute('uv', new THREE.BufferAttribute(uvs, 2));
+      geometry.setAttribute('ageOffset', new THREE.BufferAttribute(ageOffsets, 1));
+      geometry.setIndex(new THREE.BufferAttribute(indices, 1));
+    });
   });
 
   const material = new THREE.ShaderMaterial();
-  const loader = new THREE.TextureLoader();
+  const loader = useLoader(THREE.TextureLoader);
 
-  // Particle texture
-  const texture = $derived(loader.load(ParticleData[props.type].url));
+  // Track current texture for disposal
+  let currentTexture: THREE.Texture | null = $state(null);
+
+  // Add cleanup on component destruction
+  onDestroy(() => {
+    geometry?.dispose();
+    if (currentTexture) {
+      currentTexture.dispose();
+      currentTexture = null;
+    }
+  });
 
   // Create a derived value for uniforms that updates when props change
   const uniforms = $derived({
     uTime: { value: 0 },
-    uTexture: { value: texture },
+    uTexture: { value: currentTexture },
     uOpacity: { value: opacity },
     uColor: { value: new THREE.Color(props.color) },
 
@@ -167,6 +181,19 @@
     uFadeInTime: { value: props.fadeInTime },
     uFadeOutTime: { value: props.fadeOutTime },
     uScale: { value: props.scale }
+  });
+
+  $effect(() => {
+    loader.load(ParticleData[props.type].url).then((newTexture) => {
+      untrack(() => {
+        currentTexture?.dispose();
+        currentTexture = newTexture;
+
+        if (material.uniforms.uTexture) {
+          material.uniforms.uTexture.value = newTexture;
+        }
+      });
+    });
   });
 
   // Update material uniforms whenever they change

--- a/packages/ui/src/lib/components/Stage/components/Scene/Scene.svelte
+++ b/packages/ui/src/lib/components/Stage/components/Scene/Scene.svelte
@@ -42,7 +42,7 @@
   let needsResize = true;
   let loadingState = SceneLoadingState.LoadingMap;
 
-  const composer = new EffectComposer(renderer);
+  let composer = new EffectComposer(renderer);
 
   onMount(() => {
     let before = autoRender.current;
@@ -87,7 +87,8 @@
     // Need to convert the LUT to a LookupTexture
     Promise.resolve(getLUT(postProcessing.lut.url))
       .then((lut) => {
-        composer.removeAllPasses();
+        composer.dispose();
+        composer = new EffectComposer(renderer);
 
         const effects = [];
 


### PR DESCRIPTION
# What Changed
- Dispose of old textures
- Dispose of geometry for ParticleEffect
- Properly dispose of effects composer and passes
- Switched all texture loading to use the Threlte `useLoader`
- Disable perf in docs app due to Threlte / Three.js mismatch

# How was this tested?
Used the Spector.js Chrome browser extension. Observed the `Buffer` memory was increasing over time. After proper disposal of particle geometry, allocated buffer memory now remains constant when changing scenes and weather parameters.

## Before

<img width="746" alt="image" src="https://github.com/user-attachments/assets/6015a400-1dd4-417b-b437-3924c831e5be" />


## After
<img width="874" alt="image" src="https://github.com/user-attachments/assets/e9d382d1-c48d-4e90-a489-39604fcfedb0" />
