### PR TITLE
Move Editor's link popover to a portal

### DIFF
--- a/packages/ui/src/lib/components/Editor/Editor.svelte
+++ b/packages/ui/src/lib/components/Editor/Editor.svelte
@@ -67,7 +67,7 @@
   // Create portal container in body when component is mounted
   function createPortalContainer() {
     // Check if portal container already exists
-    const existingContainer = document.getElementById('editor-link-portal');
+    const existingContainer = document.getElementById('editorLinkPortal');
     if (existingContainer) {
       portalContainer = existingContainer as HTMLDivElement;
       return;
@@ -75,11 +75,7 @@
 
     // Create a new portal container
     const container = document.createElement('div');
-    container.id = 'editor-link-portal';
-    container.style.position = 'absolute';
-    container.style.top = '0';
-    container.style.left = '0';
-    container.style.zIndex = '9999';
+    container.id = 'editorLinkPortal';
     document.body.appendChild(container);
     portalContainer = container;
   }
@@ -673,14 +669,14 @@
     margin-bottom: 0.75rem;
   }
 
-  :global(#editor-link-portal) {
+  :global(#editorLinkPortal) {
     position: absolute;
     top: 0;
     left: 0;
     z-index: 9999;
     pointer-events: none;
   }
-  :global(#editor-link-portal .linkPopover) {
+  :global(#editorLinkPortal .linkPopover) {
     pointer-events: auto;
   }
   :global {

--- a/packages/ui/src/lib/components/Editor/Editor.svelte
+++ b/packages/ui/src/lib/components/Editor/Editor.svelte
@@ -62,6 +62,27 @@
   let currentLinkElement: HTMLAnchorElement | null = $state(null);
   let currentLinkUrl = $state('');
   let cleanupAutoUpdate: (() => void) | undefined;
+  let portalContainer: HTMLDivElement | undefined = $state();
+
+  // Create portal container in body when component is mounted
+  function createPortalContainer() {
+    // Check if portal container already exists
+    const existingContainer = document.getElementById('editor-link-portal');
+    if (existingContainer) {
+      portalContainer = existingContainer as HTMLDivElement;
+      return;
+    }
+
+    // Create a new portal container
+    const container = document.createElement('div');
+    container.id = 'editor-link-portal';
+    container.style.position = 'absolute';
+    container.style.top = '0';
+    container.style.left = '0';
+    container.style.zIndex = '9999';
+    document.body.appendChild(container);
+    portalContainer = container;
+  }
 
   const textType = $derived.by(() => {
     if (isH1) return 'Huge';
@@ -88,6 +109,9 @@
   }
 
   onMount(() => {
+    // Create portal container
+    createPortalContainer();
+
     // Default empty content
     const emptyContent = { type: 'doc', content: [{ type: 'paragraph' }] };
 
@@ -168,6 +192,18 @@
     if (cleanupAutoUpdate) {
       cleanupAutoUpdate();
     }
+
+    // Clean up the popover element from the portal container
+    if (linkPopoverElement && portalContainer && portalContainer.contains(linkPopoverElement)) {
+      portalContainer.removeChild(linkPopoverElement);
+    }
+
+    // Remove portal container if it exists and we are the last editor instance
+    if (portalContainer && portalContainer.childNodes.length === 0) {
+      if (document.body.contains(portalContainer)) {
+        document.body.removeChild(portalContainer);
+      }
+    }
   });
 
   function handleEditorClick(e: MouseEvent) {
@@ -196,7 +232,9 @@
         !linkPopoverElement.contains(target) &&
         currentLinkElement !== target &&
         !currentLinkElement?.contains(target) &&
-        !target.closest('.editor__btn') // Don't close when clicking toolbar buttons
+        !target.closest('.editor__btn') && // Don't close when clicking toolbar buttons
+        // Also check if we're clicking inside the editor but not on a link
+        !(element?.contains(target) && !target.closest('a'))
       ) {
         hideLinkPopover();
       }
@@ -222,7 +260,23 @@
   }
 
   function showLinkPopover(anchorElement: HTMLElement) {
-    if (!linkPopoverElement) return;
+    if (!linkPopoverElement || !portalContainer) return;
+
+    // Move the popover element to the portal container if it's not already there
+    if (!portalContainer.contains(linkPopoverElement)) {
+      // Create a new popover element in the portal container
+      const popoverClone = linkPopoverElement.cloneNode(true) as HTMLDivElement;
+      portalContainer.appendChild(popoverClone);
+
+      // Update our reference to the new popover element
+      linkPopoverElement = popoverClone;
+
+      // Find the input element within the cloned popover
+      linkInputElement = popoverClone.querySelector('.linkPopover__input') as HTMLInputElement;
+
+      // Setup event handlers for the portal popover
+      setupPortalPopoverEvents();
+    }
 
     linkPopoverVisible = true;
 
@@ -239,7 +293,9 @@
         if (linkPopoverElement) {
           Object.assign(linkPopoverElement.style, {
             left: `${x}px`,
-            top: `${y}px`
+            top: `${y}px`,
+            position: 'absolute',
+            display: 'block'
           });
         }
       });
@@ -262,6 +318,11 @@
     if (cleanupAutoUpdate) {
       cleanupAutoUpdate();
       cleanupAutoUpdate = undefined;
+    }
+
+    // Hide the popover in the portal if it exists
+    if (linkPopoverElement && portalContainer && portalContainer.contains(linkPopoverElement)) {
+      linkPopoverElement.style.display = 'none';
     }
   }
 
@@ -306,6 +367,30 @@
     if (currentLinkUrl) {
       window.open(currentLinkUrl, '_blank');
       hideLinkPopover();
+    }
+  }
+
+  // Setup portal popover event handlers when the component is mounted
+  function setupPortalPopoverEvents() {
+    if (!linkPopoverElement || !portalContainer) return;
+
+    // Add event handlers for the buttons in the portal popover
+    const confirmButton = linkPopoverElement.querySelector('.linkPopover__inputRow button') as HTMLElement;
+    if (confirmButton) {
+      // Use the correct typing approach for TypeScript with Svelte 5
+      (confirmButton as unknown as { onclick: typeof addOrUpdateLink }).onclick = addOrUpdateLink;
+    }
+
+    // Add event handlers for the visit and remove buttons
+    const buttons = linkPopoverElement.querySelectorAll('.linkPopover__actions button');
+    if (buttons.length >= 2) {
+      (buttons[0] as unknown as { onclick: typeof visitLink }).onclick = visitLink;
+      (buttons[1] as unknown as { onclick: typeof removeLink }).onclick = removeLink;
+    }
+
+    // Add event handler for the input element
+    if (linkInputElement) {
+      (linkInputElement as unknown as { onkeydown: typeof handleLinkInputKeydown }).onkeydown = handleLinkInputKeydown;
     }
   }
 
@@ -458,8 +543,8 @@
     <div bind:this={element}></div>
   </div>
 
-  <!-- Link Popover -->
-  <div bind:this={linkPopoverElement} class="linkPopover" class:linkPopover--visible={linkPopoverVisible}>
+  <!-- Link Popover Template (hidden) - Will be cloned to portal container -->
+  <div bind:this={linkPopoverElement} class="linkPopover" style="display: none;">
     <div class="linkPopover__content">
       <div class="linkPopover__inputRow">
         <Input
@@ -561,12 +646,8 @@
   /* Link Popover Styles */
   .linkPopover {
     position: absolute;
-    z-index: 100;
-    display: none;
+    z-index: 9999;
     filter: drop-shadow(0 4px 6px rgba(0, 0, 0, 0.1));
-  }
-  .linkPopover--visible {
-    display: block;
   }
   .linkPopover__content {
     box-shadow: var(--shadow-1);
@@ -580,6 +661,17 @@
     display: flex;
     gap: 0.5rem;
     margin-bottom: 0.75rem;
+  }
+
+  :global(#editor-link-portal) {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 9999;
+    pointer-events: none;
+  }
+  :global(#editor-link-portal .linkPopover) {
+    pointer-events: auto;
   }
   :global {
     .tiptap:focus-visible {

--- a/packages/ui/src/lib/components/Editor/Editor.svelte
+++ b/packages/ui/src/lib/components/Editor/Editor.svelte
@@ -278,6 +278,11 @@
       setupPortalPopoverEvents();
     }
 
+    // Always update the input field value with the current link URL
+    if (linkInputElement) {
+      linkInputElement.value = currentLinkUrl;
+    }
+
     linkPopoverVisible = true;
 
     // Position the popover using Floating UI
@@ -388,9 +393,14 @@
       (buttons[1] as unknown as { onclick: typeof removeLink }).onclick = removeLink;
     }
 
-    // Add event handler for the input element
     if (linkInputElement) {
+      // Set up keydown handler for Enter key
       (linkInputElement as unknown as { onkeydown: typeof handleLinkInputKeydown }).onkeydown = handleLinkInputKeydown;
+
+      // Set up input handler to keep our state variable in sync
+      linkInputElement.addEventListener('input', (e: Event) => {
+        currentLinkUrl = (e.target as HTMLInputElement).value;
+      });
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/Siege-Perilous/tableslayer/issues/272 by moving the link popover to a portal outside the editor.

![image](https://github.com/user-attachments/assets/d4e1b815-563a-4bd5-8f22-f26007cfb9ac)

