### PR TITLE
Use centroid based positioning for gestures

### DIFF
--- a/packages/ui/src/lib/components/Stage/components/PointerInputManager/PointerInputManager.svelte
+++ b/packages/ui/src/lib/components/Stage/components/PointerInputManager/PointerInputManager.svelte
@@ -108,13 +108,22 @@
     const { dx, dy } = calculateRotatedMovement(pointers[0], stageProps.scene.rotation);
     const { curDiff, zoomDelta, curAngle, angleDelta } = calculatePinchAndRotation(pointers);
 
+    // Check if this is Firefox to apply special handling for pan calculations
+    const isFirefox = navigator.userAgent.toLowerCase().includes('firefox');
+
     if (prevDiff > 0) {
       if (isMapControl) {
-        onMapPan(dx, dy);
+        // In Firefox, disable panning during multi-touch as movement values are unreliable
+        if (!isFirefox) {
+          onMapPan(dx, dy);
+        }
         onMapZoom(Math.max(minZoom, Math.min(stageProps.map.zoom - zoomDelta, maxZoom)));
         onMapRotate(stageProps.map.rotation - (angleDelta * 180) / Math.PI);
       } else {
-        onScenePan(dx, dy);
+        // In Firefox, disable panning during multi-touch as movement values are unreliable
+        if (!isFirefox) {
+          onScenePan(dx, dy);
+        }
         onSceneZoom(Math.max(minZoom, Math.min(stageProps.scene.zoom - zoomDelta, maxZoom)));
         onSceneRotate(stageProps.scene.rotation + (angleDelta * 180) / Math.PI);
       }

--- a/packages/ui/src/lib/components/Stage/components/PointerInputManager/PointerInputManager.svelte
+++ b/packages/ui/src/lib/components/Stage/components/PointerInputManager/PointerInputManager.svelte
@@ -36,6 +36,7 @@
   let prevDiff = $state(-1);
   let prevAngle = $state(0);
   let isDragging = $state(false);
+  let lastPointerCount = $state(0);
 
   $effect(() => {
     if (stageElement) {
@@ -132,6 +133,16 @@
       pointerCache[index] = e;
     }
 
+    // Reset multi-touch state when transitioning from single to multi-touch
+    // This prevents using stale movement data from single-touch phase
+    if (lastPointerCount !== pointerCache.length) {
+      if (pointerCache.length >= 2 && lastPointerCount < 2) {
+        prevDiff = -1;
+        prevAngle = 0;
+      }
+      lastPointerCount = pointerCache.length;
+    }
+
     // Handle different pointer counts
     switch (pointerCache.length) {
       case 1:
@@ -158,6 +169,7 @@
       isDragging = false;
       prevDiff = -1;
       prevAngle = 0;
+      lastPointerCount = 0;
     }
   }
 </script>

--- a/packages/ui/src/lib/components/Stage/components/PointerInputManager/PointerInputManager.svelte
+++ b/packages/ui/src/lib/components/Stage/components/PointerInputManager/PointerInputManager.svelte
@@ -130,23 +130,9 @@
   function handleMultiPointer(pointers: PointerEvent[], isMapControl: boolean) {
     const { curDiff, zoomDelta, curAngle, angleDelta } = calculatePinchAndRotation(pointers);
 
-    // Check if this is Firefox to use centroid-based pan calculation
-    const isFirefox = navigator.userAgent.toLowerCase().includes('firefox');
-
-    let dx = 0,
-      dy = 0;
-    if (isFirefox) {
-      // Use centroid-based movement calculation for Firefox
-      const centroidResult = calculateCentroidMovement(pointers, stageProps.scene.rotation);
-      dx = centroidResult.dx;
-      dy = centroidResult.dy;
-      prevCentroid = centroidResult.curCentroid;
-    } else {
-      // Use original movement-based calculation for other browsers
-      const movement = calculateRotatedMovement(pointers[0], stageProps.scene.rotation);
-      dx = movement.dx;
-      dy = movement.dy;
-    }
+    // Use centroid-based movement (center of the two pointers)
+    const { dx, dy, curCentroid } = calculateCentroidMovement(pointers, stageProps.scene.rotation);
+    prevCentroid = curCentroid;
 
     if (prevDiff > 0) {
       if (isMapControl) {
@@ -179,7 +165,7 @@
       if (pointerCache.length >= 2 && lastPointerCount < 2) {
         prevDiff = -1;
         prevAngle = 0;
-        prevCentroid = null; // Reset centroid for Firefox
+        prevCentroid = null;
       }
       lastPointerCount = pointerCache.length;
     }

--- a/packages/ui/src/lib/components/Stage/components/PointerInputManager/PointerInputManager.svelte
+++ b/packages/ui/src/lib/components/Stage/components/PointerInputManager/PointerInputManager.svelte
@@ -80,7 +80,14 @@
     const zoomDelta = -(curDiff - prevDiff) * zoomSensitivity;
 
     const curAngle = Math.atan2(p2.clientY - p1.clientY, p2.clientX - p1.clientX);
-    const angleDelta = curAngle - prevAngle;
+    let angleDelta = curAngle - prevAngle;
+
+    // Normalize angle delta to handle wrapping around ±π boundary
+    if (angleDelta > Math.PI) {
+      angleDelta -= 2 * Math.PI;
+    } else if (angleDelta < -Math.PI) {
+      angleDelta += 2 * Math.PI;
+    }
 
     return { curDiff, zoomDelta, curAngle, angleDelta };
   }


### PR DESCRIPTION
Fixes an issue with gestures causing some boundary issues in FF mobile. Also makes the center of the rotation feel better because it uses a point in between the fingers as the rotation.