### PR TITLE
Protect image uploads from overwriting drawing updates

### DIFF
--- a/.github/workflows/destroydb.yml
+++ b/.github/workflows/destroydb.yml
@@ -24,7 +24,7 @@ jobs:
         working-directory: apps/web
         run: |
           echo "Deleting PartyKit deployment for PR #${{ github.event.pull_request.number }}"
-          npx partykit delete --domain tableslayer.com --preview pr-${{ github.event.pull_request.number }} --yes || echo "PartyKit deployment not found or already deleted"
+          npx partykit delete --name tableslayer --preview pr-${{ github.event.pull_request.number }} --force || echo "PartyKit deployment not found or already deleted"
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_WORKERS_KEY }}

--- a/packages/ui/src/lib/components/Stage/components/AnnotationLayer/AnnotationLayer.svelte
+++ b/packages/ui/src/lib/components/Stage/components/AnnotationLayer/AnnotationLayer.svelte
@@ -22,6 +22,11 @@
   let mesh: THREE.Mesh = $state(new THREE.Mesh());
   let drawing = false;
 
+  // Export drawing state so parent can check it
+  export function isDrawing() {
+    return drawing;
+  }
+
   // If mouse leaves the drawing area, we need to reset the start position
   // when it re-enters the drawing area to prevent the drawing from "jumping"
   // to the new point

--- a/packages/ui/src/lib/components/Stage/components/AnnotationLayer/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/AnnotationLayer/types.ts
@@ -58,4 +58,5 @@ export interface AnnotationLayerData {
 export interface AnnotationExports {
   clear: (layerId: string) => void;
   toPng: () => Promise<Blob>;
+  isDrawing: () => boolean;
 }

--- a/packages/ui/src/lib/components/Stage/components/FogOfWarLayer/FogOfWarLayer.svelte
+++ b/packages/ui/src/lib/components/Stage/components/FogOfWarLayer/FogOfWarLayer.svelte
@@ -27,6 +27,11 @@
   let drawing = false;
   let hasFinishedDrawing = false;
 
+  // Export drawing state so parent can check it
+  export function isDrawing() {
+    return drawing;
+  }
+
   // If mouse leaves the drawing area, we need to reset the start position
   // when it re-enters the drawing area to prevent the drawing from "jumping"
   // to the new point

--- a/packages/ui/src/lib/components/Stage/components/FogOfWarLayer/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/FogOfWarLayer/types.ts
@@ -110,4 +110,5 @@ export interface FogOfWarExports {
   clearFog: () => void;
   resetFog: () => void;
   toPng: () => Promise<Blob>;
+  isDrawing: () => boolean;
 }

--- a/packages/ui/src/lib/components/Stage/components/MapLayer/MapLayer.svelte
+++ b/packages/ui/src/lib/components/Stage/components/MapLayer/MapLayer.svelte
@@ -117,7 +117,8 @@
   export const fogOfWar = {
     clear: () => fogOfWarLayer.clearFog(),
     reset: () => fogOfWarLayer.resetFog(),
-    toPng: () => fogOfWarLayer.toPng()
+    toPng: () => fogOfWarLayer.toPng(),
+    isDrawing: () => fogOfWarLayer?.isDrawing() ?? false
   };
 </script>
 

--- a/packages/ui/src/lib/components/Stage/components/MapLayer/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/MapLayer/types.ts
@@ -43,5 +43,6 @@ export interface MapLayerExports {
     clear: () => void;
     reset: () => void;
     toPng: () => Promise<Blob>;
+    isDrawing: () => boolean;
   };
 }

--- a/packages/ui/src/lib/components/Stage/components/Scene/Scene.svelte
+++ b/packages/ui/src/lib/components/Stage/components/Scene/Scene.svelte
@@ -332,7 +332,8 @@
   }
 
   export const annotations = {
-    clear: (layerId: string) => annotationsLayer.clear(layerId)
+    clear: (layerId: string) => annotationsLayer.clear(layerId),
+    isDrawing: () => annotationsLayer?.isDrawing() ?? false
   };
 
   export const map = {
@@ -345,7 +346,8 @@
   export const fogOfWar = {
     clear: () => mapLayer.fogOfWar.clear(),
     reset: () => mapLayer.fogOfWar.reset(),
-    toPng: () => mapLayer.fogOfWar.toPng()
+    toPng: () => mapLayer.fogOfWar.toPng(),
+    isDrawing: () => mapLayer?.fogOfWar?.isDrawing() ?? false
   };
 </script>
 

--- a/packages/ui/src/lib/components/Stage/components/Scene/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/Scene/types.ts
@@ -61,12 +61,14 @@ export interface SceneExports {
 
   annotations: {
     clear: (layerId: string) => void;
+    isDrawing: () => boolean;
   };
 
   fogOfWar: {
     clear: () => void;
     reset: () => void;
     toPng: () => Promise<Blob>;
+    isDrawing: () => boolean;
   };
 
   map: {

--- a/packages/ui/src/lib/components/Stage/components/Stage/Stage.svelte
+++ b/packages/ui/src/lib/components/Stage/components/Stage/Stage.svelte
@@ -26,7 +26,8 @@
   setContext('callbacks', callbacks);
 
   export const annotations = {
-    clear: (layerId: string) => sceneRef.annotations.clear(layerId)
+    clear: (layerId: string) => sceneRef.annotations.clear(layerId),
+    isDrawing: () => sceneRef?.annotations?.isDrawing() ?? false
   };
 
   export const map = {
@@ -37,7 +38,8 @@
   export const fogOfWar = {
     clear: () => sceneRef?.fogOfWar.clear(),
     reset: () => sceneRef?.fogOfWar.reset(),
-    toPng: () => sceneRef?.fogOfWar.toPng()
+    toPng: () => sceneRef?.fogOfWar.toPng(),
+    isDrawing: () => sceneRef?.fogOfWar?.isDrawing() ?? false
   };
 
   export const scene = {

--- a/packages/ui/src/lib/components/Stage/components/Stage/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/Stage/types.ts
@@ -74,12 +74,14 @@ export type StageProps = {
 export interface StageExports {
   annotations: {
     clear: (layerId: string) => void;
+    isDrawing: () => boolean;
   };
 
   fogOfWar: {
     clear: () => void;
     reset: () => void;
     toPng: () => Promise<Blob>;
+    isDrawing: () => boolean;
   };
   map: {
     fit: () => void;


### PR DESCRIPTION
Previously if a user made too many edits to the annotation / fog layers, the round trip to upload the file and update the stage would take too long, causing the game to overwrite new drawings in place of new ones. This PR adds a new export `isDrawing` to the component that lets the parent know when to abort the upload process.