### PR TITLE
Fix editor popup position, add Sept changelog

### DIFF
--- a/apps/web/src/lib/changelog/2025-09.md
+++ b/apps/web/src/lib/changelog/2025-09.md
@@ -1,0 +1,17 @@
+#### Set fog opacity unique to player or DM view
+
+<video controls width="100%">
+  <source src="https://files.tableslayer.com/changelog/sept-fog-demo-web.mp4" type="video/mp4">
+  Your browser does not support the video tag.
+</video>
+
+The shared play field can how have a different fog opacity than the one used for the Editor. This makes is easy to hide features with fog to players, but still retain the ability to view those features in your editor. [#336](https://github.com/Siege-Perilous/tableslayer/pull/336)
+
+#### Small features
+
+- Added a product changelog to track features. [#333](https://github.com/Siege-Perilous/tableslayer/pull/333)
+- Added a promo system to provide free lifetime keys as giveaways. [#331](https://github.com/Siege-Perilous/tableslayer/pull/331)
+
+#### Fixes
+
+- The popover in the Text Editor now positions correctly on mobile devices. [#335](https://github.com/Siege-Perilous/tableslayer/pull/335)


### PR DESCRIPTION
The popover for the Text Editor was incorrectly positioning in mobile. It also would go directly to the URL, rather than relying on the user to click again within the popup.