### PR TITLE
Make cursor updates and rendering native to the Stage component

### DIFF
--- a/apps/web/src/lib/changelog/2025-09.md
+++ b/apps/web/src/lib/changelog/2025-09.md
@@ -24,3 +24,4 @@ Table Slayer now supports the ability to use movie files (MP4, webm) or GIF file
 #### Fixes
 
 - The popover in the Text Editor now positions correctly on mobile devices. [#335](https://github.com/Siege-Perilous/tableslayer/pull/335)
+- The cursor system now renders directly in the play field, rather than being calculated with complicated math, significantly improving performance. [#336](https://github.com/Siege-Perilous/tableslayer/pull/336)

--- a/apps/web/src/lib/utils/yjs/PartyDataManager.ts
+++ b/apps/web/src/lib/utils/yjs/PartyDataManager.ts
@@ -18,8 +18,9 @@ export interface SceneMetadata {
 
 export interface CursorData {
   userId: string;
-  position: { x: number; y: number };
-  normalizedPosition: { x: number; y: number };
+  worldPosition: { x: number; y: number; z: number };
+  color?: string;
+  label?: string;
   lastMoveTime: number;
   clientId?: number;
 }
@@ -199,14 +200,15 @@ export class PartyDataManager {
   }
 
   /**
-   * Update cursor position using Y.js awareness
+   * Update cursor position using Y.js awareness with world coordinates
    */
-  updateCursor(position: { x: number; y: number }, normalizedPosition: { x: number; y: number }) {
+  updateCursor(worldPosition: { x: number; y: number; z: number }, color?: string, label?: string) {
     if (this.isConnected && this.gameSessionProvider.awareness) {
       this.gameSessionProvider.awareness.setLocalStateField('cursor', {
         userId: this.userId,
-        position,
-        normalizedPosition,
+        worldPosition,
+        color: color || '#ffffff',
+        label: label || this.userId,
         lastMoveTime: Date.now()
       });
     }

--- a/apps/web/src/lib/utils/yjs/stores.ts
+++ b/apps/web/src/lib/utils/yjs/stores.ts
@@ -52,8 +52,8 @@ export function usePartyData() {
     subscribe: (callback: () => void) => partyDataManager!.subscribe(callback),
 
     // Cursor management
-    updateCursor: (position: { x: number; y: number }, normalizedPosition: { x: number; y: number }) =>
-      partyDataManager!.updateCursor(position, normalizedPosition),
+    updateCursor: (worldPosition: { x: number; y: number; z: number }, color?: string, label?: string) =>
+      partyDataManager!.updateCursor(worldPosition, color, label),
     getCursors: () => partyDataManager!.getCursors(),
 
     // Measurement management

--- a/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
+++ b/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
@@ -635,12 +635,13 @@
       }
       partyData = usePartyData();
 
+      // Generate a consistent color for this user session
+      const userColor = `#${Math.floor(Math.random() * 16777215)
+        .toString(16)
+        .padStart(6, '0')}`;
+
       // Create throttled cursor update function (30 FPS for smooth LCD TV display)
       throttledCursorUpdate = throttle((worldPosition: { x: number; y: number; z: number }) => {
-        // Generate a color for this user (could be stored in user data)
-        const userColor = `#${Math.floor(Math.random() * 16777215)
-          .toString(16)
-          .padStart(6, '0')}`;
         partyData!.updateCursor(worldPosition, userColor, user.email);
       }, 33); // 33ms = ~30 FPS
 

--- a/apps/web/src/routes/(app)/[party]/play/+page@.svelte
+++ b/apps/web/src/routes/(app)/[party]/play/+page@.svelte
@@ -11,8 +11,10 @@
   import { type SceneData, type MeasurementData } from '$lib/utils/yjs/PartyDataManager';
 
   type CursorData = {
-    position: { x: number; y: number };
-    user: { id: string; email: string };
+    worldPosition: { x: number; y: number; z: number };
+    userId: string;
+    color?: string;
+    label?: string;
     lastMoveTime: number;
     fadedOut: boolean;
   };
@@ -20,6 +22,18 @@
   let cursors: Record<string, CursorData> = $state({});
   let measurements: Record<string, MeasurementData> = $state({});
   let latestMeasurement: MeasurementData | null = $state(null);
+
+  // Convert cursors to format expected by CursorLayer
+  let cursorArray = $derived(
+    Object.entries(cursors).map(([id, cursor]) => ({
+      id,
+      worldPosition: cursor.worldPosition || { x: 0, y: 0, z: 0 },
+      color: cursor.color || '#ffffff',
+      label: cursor.label || cursor.userId,
+      opacity: cursor.fadedOut ? 0 : 1,
+      lastUpdateTime: cursor.lastMoveTime
+    }))
+  );
 
   let { data } = $props();
   const { user, party } = $derived(data);
@@ -172,60 +186,7 @@
   // Track the current game session ID to detect changes
   let currentGameSessionId = $state<string | undefined>(data.activeGameSession?.id);
 
-  // Cursor update handler - moved to component scope so it can be reused
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const handleCursorUpdate = (payload: any) => {
-    const { normalizedPosition, user, zoom: editorZoom, cursorKey } = payload;
-
-    const stageBounds = stageElement?.getBoundingClientRect();
-    if (!stageBounds) return;
-
-    const stageWidth = stageBounds.width;
-    const stageHeight = stageBounds.height;
-
-    const clientZoom = stageProps.scene.zoom;
-
-    const displayWidthClient = stageProps.display.resolution.x * clientZoom;
-    const displayHeightClient = stageProps.display.resolution.y * clientZoom;
-
-    const displayWidthEditor = stageProps.display.resolution.x * editorZoom;
-    const displayHeightEditor = stageProps.display.resolution.y * editorZoom;
-
-    const horizontalMargin = (stageWidth - displayWidthClient) / 2;
-    const verticalMargin = (stageHeight - displayHeightClient) / 2;
-
-    const rectX = normalizedPosition.x * displayWidthEditor;
-    const rectY = normalizedPosition.y * displayHeightEditor;
-
-    const adjustedX = rectX * (displayWidthClient / displayWidthEditor);
-    const adjustedY = rectY * (displayHeightClient / displayHeightEditor);
-
-    const absoluteXClient = horizontalMargin + adjustedX;
-    const absoluteYClient = verticalMargin + adjustedY;
-
-    // Use cursorKey if provided, otherwise fall back to user.id
-    const key = cursorKey || user.id;
-
-    // Check if cursor exists and if position actually changed
-    const existingCursor = cursors[key];
-    const positionChanged =
-      !existingCursor || existingCursor.position.x !== absoluteXClient || existingCursor.position.y !== absoluteYClient;
-
-    // Only update lastMoveTime if position actually changed
-    const updateTime = positionChanged ? Date.now() : existingCursor?.lastMoveTime || Date.now();
-
-    // Position change logging removed - too noisy for regular use
-
-    cursors = {
-      ...cursors,
-      [key]: {
-        user,
-        position: { x: absoluteXClient, y: absoluteYClient },
-        lastMoveTime: updateTime,
-        fadedOut: positionChanged ? false : existingCursor?.fadedOut || false
-      }
-    };
-  };
+  // Cursor handling is now done through Three.js world coordinates
 
   onMount(() => {
     if (isMounted) {
@@ -306,12 +267,17 @@
         // Update or add cursors from Y.js
         Object.entries(yjsCursors).forEach(([cursorKey, cursorData]) => {
           // Transform cursor data to match playfield format
-          handleCursorUpdate({
-            normalizedPosition: cursorData.normalizedPosition,
-            user: { id: cursorData.userId, email: cursorData.userId }, // TODO: Get actual user data
-            zoom: 1, // TODO: Get editor zoom from cursor data
-            cursorKey // Pass the unique key for tracking
-          });
+          cursors = {
+            ...cursors,
+            [cursorKey]: {
+              worldPosition: cursorData.worldPosition || { x: 0, y: 0, z: 0 },
+              userId: cursorData.userId,
+              color: cursorData.color,
+              label: cursorData.label,
+              lastMoveTime: cursorData.lastMoveTime || Date.now(),
+              fadedOut: false
+            }
+          };
         });
 
         // Update measurements from Y.js awareness
@@ -475,12 +441,17 @@
         // Update or add cursors from Y.js
         Object.entries(yjsCursors).forEach(([cursorKey, cursorData]) => {
           // Transform cursor data to match playfield format
-          handleCursorUpdate({
-            normalizedPosition: cursorData.normalizedPosition,
-            user: { id: cursorData.userId, email: cursorData.userId }, // TODO: Get actual user data
-            zoom: 1, // TODO: Get editor zoom from cursor data
-            cursorKey // Pass the unique key for tracking
-          });
+          cursors = {
+            ...cursors,
+            [cursorKey]: {
+              worldPosition: cursorData.worldPosition || { x: 0, y: 0, z: 0 },
+              userId: cursorData.userId,
+              color: cursorData.color,
+              label: cursorData.label,
+              lastMoveTime: cursorData.lastMoveTime || Date.now(),
+              fadedOut: false
+            }
+          };
         });
 
         // Update measurements from Y.js awareness
@@ -531,11 +502,7 @@
     }
   });
 
-  const getRandomColor = (): string => {
-    return `#${Math.floor(Math.random() * 16777215)
-      .toString(16)
-      .padStart(6, '0')}`;
-  };
+  // Color generation removed - now handled in cursor data
 
   function onSceneUpdate(offset: { x: number; y: number }, zoom: number) {
     devLog('playfield', '[Playfield] onSceneUpdate called:', { offset, zoom });
@@ -608,28 +575,7 @@
     }
   });
 
-  $effect(() => {
-    const interval = setInterval(() => {
-      const now = Date.now();
-      let needsUpdate = false;
-      const updatedCursors = { ...cursors };
-
-      for (const [cursorKey, cursor] of Object.entries(updatedCursors)) {
-        if (!cursor.fadedOut && now - cursor.lastMoveTime > fadeOutDelay) {
-          // Mark the cursor as faded out after inactivity
-          updatedCursors[cursorKey] = { ...cursor, fadedOut: true };
-          needsUpdate = true;
-        }
-      }
-
-      // Only update if something changed
-      if (needsUpdate) {
-        cursors = updatedCursors;
-      }
-    }, 250);
-
-    return () => clearInterval(interval);
-  });
+  // Fade-out logic is now handled in CursorLayer component via opacity calculation
 
   // Effect to handle active scene changes
   $effect(() => {
@@ -783,17 +729,11 @@
       onMeasurementUpdate: () => {},
       onMeasurementEnd: () => {}
     }}
+    cursors={cursorArray}
+    trackLocalCursor={false}
   />
 
-  {#each Object.values(cursors) as { user, position, fadedOut }}
-    <div
-      class="cursor"
-      style={`left: ${position.x}px; top: ${position.y}px; transform: translate(-0.75rem, -0.25rem); opacity: ${fadedOut ? 0 : 1}; transition: opacity 0.5s ease;`}
-    >
-      <div class="cursor__pointer"></div>
-      <span class="cursor__label" style={`background-color: ${getRandomColor()}`}>{user.email}</span>
-    </div>
-  {/each}
+  <!-- Cursors are now rendered in Three.js via the CursorLayer component -->
 </div>
 
 <style>
@@ -837,30 +777,5 @@
     display: none;
     visibility: hidden;
     opacity: 0;
-  }
-  .cursor {
-    position: fixed;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    pointer-events: none;
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
-    z-index: 10;
-    font-size: 12px;
-  }
-
-  .cursor__pointer {
-    border-radius: 50%;
-    width: 1.5rem;
-    height: 1.5rem;
-    border: solid 0.25rem white;
-    background-color: black;
-  }
-
-  .cursor__label {
-    font-size: 12px;
-    font-weight: 600;
-    color: black;
-    display: none;
   }
 </style>

--- a/packages/ui/src/lib/components/Stage/components/CursorLayer/CursorLayer.svelte
+++ b/packages/ui/src/lib/components/Stage/components/CursorLayer/CursorLayer.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  import * as THREE from 'three';
+  import { T, useTask } from '@threlte/core';
+  import { Text } from '@threlte/extras';
+  import type { CursorData, CursorLayerProps } from './types';
+  import { SceneLayer } from '../Scene/types';
+
+  interface Props {
+    props: CursorLayerProps;
+  }
+
+  const { props }: Props = $props();
+
+  // Track current time for fade calculations
+  let currentTime = $state(Date.now());
+
+  useTask(() => {
+    currentTime = Date.now();
+  });
+
+  // Calculate opacity for each cursor based on fade settings
+  const getCursorOpacity = (cursor: CursorData): number => {
+    const timeSinceUpdate = currentTime - cursor.lastUpdateTime;
+
+    if (timeSinceUpdate < props.fadeOutDelay) {
+      return cursor.opacity;
+    }
+
+    const fadeProgress = (timeSinceUpdate - props.fadeOutDelay) / props.fadeOutDuration;
+    if (fadeProgress >= 1) {
+      return 0;
+    }
+
+    return cursor.opacity * (1 - fadeProgress);
+  };
+
+  // Create cursor geometry (reusable)
+  const cursorGeometry = new THREE.CircleGeometry(8, 16);
+  const cursorOutlineGeometry = new THREE.RingGeometry(7, 10, 16);
+</script>
+
+{#each props.cursors as cursor (cursor.id)}
+  {@const opacity = getCursorOpacity(cursor)}
+
+  {#if opacity > 0}
+    <!-- Cursor group positioned in world space -->
+    <T.Group
+      position={[cursor.worldPosition.x, cursor.worldPosition.y, cursor.worldPosition.z + 0.1]}
+      layers={[SceneLayer.Overlay]}
+    >
+      <!-- White outline -->
+      <T.Mesh geometry={cursorOutlineGeometry}>
+        <T.MeshBasicMaterial color="#ffffff" transparent={true} {opacity} depthTest={false} />
+      </T.Mesh>
+
+      <!-- Colored center -->
+      <T.Mesh geometry={cursorGeometry}>
+        <T.MeshBasicMaterial color={cursor.color} transparent={true} opacity={opacity * 0.8} depthTest={false} />
+      </T.Mesh>
+
+      <!-- Cursor pointer triangle -->
+      <T.Mesh position={[-4, -4, 0.01]} rotation={[0, 0, -Math.PI / 4]}>
+        <T.ConeGeometry args={[4, 8, 3]} />
+        <T.MeshBasicMaterial color="#ffffff" transparent={true} {opacity} depthTest={false} />
+      </T.Mesh>
+
+      <!-- Label (if enabled and provided) -->
+      {#if props.showLabels && cursor.label}
+        <Text
+          text={cursor.label}
+          fontSize={14}
+          color={cursor.color}
+          anchorX="left"
+          anchorY="middle"
+          position={[15, 0, 0.02]}
+          outlineWidth={2}
+          outlineColor="#000000"
+          outlineOpacity={opacity}
+          fillOpacity={opacity}
+          layers={[SceneLayer.Overlay]}
+        />
+      {/if}
+    </T.Group>
+  {/if}
+{/each}

--- a/packages/ui/src/lib/components/Stage/components/CursorLayer/CursorLayer.svelte
+++ b/packages/ui/src/lib/components/Stage/components/CursorLayer/CursorLayer.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import * as THREE from 'three';
   import { T, useTask } from '@threlte/core';
-  import { Text } from '@threlte/extras';
   import type { CursorData, CursorLayerProps } from './types';
   import { SceneLayer } from '../Scene/types';
 
@@ -34,9 +33,54 @@
     return cursor.opacity * (1 - fadeProgress);
   };
 
-  // Create cursor geometry (reusable)
-  const cursorGeometry = new THREE.CircleGeometry(8, 16);
-  const cursorOutlineGeometry = new THREE.RingGeometry(7, 10, 16);
+  // Calculate cursor size based on grid
+  // Grid spacing is in inches, display size is in inches, resolution is in pixels
+  // We want the TOTAL cursor (including border) to be 0.7 times the grid size
+  const calculateCursorSize = () => {
+    if (!props.gridSpacing || !props.displaySize || !props.displayResolution) {
+      return 50; // Default size if grid info not provided
+    }
+
+    // In the Stage coordinate system:
+    // - The display resolution (e.g., 1920x1080) represents the full stage in world units
+    // - The display size (e.g., 17.77x10 inches) is the physical size
+    // - Grid spacing is in inches
+
+    // Calculate how many pixels (world units) per inch
+    const worldUnitsPerInch = props.displayResolution.x / props.displaySize.x;
+
+    // Convert grid spacing from inches to world units
+    const gridSizeInWorldUnits = props.gridSpacing * worldUnitsPerInch;
+
+    // Compensate for scene zoom (since cursor is inside the scaled object)
+    const sceneZoom = props.sceneZoom || 1;
+    const adjustedSize = gridSizeInWorldUnits / sceneZoom;
+
+    // We want the TOTAL cursor diameter (including border) to be 0.6 times the grid size
+    const targetScale = 0.6;
+    const finalSize = adjustedSize * targetScale;
+
+    return finalSize;
+  };
+
+  // Make cursor size reactive to zoom changes
+  const targetDiameter = $derived(calculateCursorSize());
+  // The outer radius is half of our target diameter - this is the full visual extent
+  const outerRadius = $derived(targetDiameter / 2);
+  // Border takes up 20% of the radius
+  const borderWidth = $derived(outerRadius * 0.2);
+  // Inner colored area is smaller by the border width
+  const innerRadius = $derived(outerRadius - borderWidth);
+
+  // Create cursor geometry with more segments for smoother edges (anti-aliasing)
+  // These need to be recreated when size changes
+  const cursorGeometry = $derived(new THREE.CircleGeometry(innerRadius, 128));
+  const cursorOutlineGeometry = $derived(new THREE.RingGeometry(innerRadius, outerRadius, 128));
+
+  // Shadow geometry - ring for softer edge, centered for top-down view
+  const shadowOuterRadius = $derived(outerRadius * 1.25);
+  const shadowInnerRadius = $derived(outerRadius * 1.05);
+  const shadowGeometry = $derived(new THREE.RingGeometry(shadowInnerRadius, shadowOuterRadius, 128));
 </script>
 
 {#each props.cursors as cursor (cursor.id)}
@@ -48,38 +92,33 @@
       position={[cursor.worldPosition.x, cursor.worldPosition.y, cursor.worldPosition.z + 0.1]}
       layers={[SceneLayer.Overlay]}
     >
-      <!-- White outline -->
-      <T.Mesh geometry={cursorOutlineGeometry}>
-        <T.MeshBasicMaterial color="#ffffff" transparent={true} {opacity} depthTest={false} />
-      </T.Mesh>
-
-      <!-- Colored center -->
-      <T.Mesh geometry={cursorGeometry}>
-        <T.MeshBasicMaterial color={cursor.color} transparent={true} opacity={opacity * 0.8} depthTest={false} />
-      </T.Mesh>
-
-      <!-- Cursor pointer triangle -->
-      <T.Mesh position={[-4, -4, 0.01]} rotation={[0, 0, -Math.PI / 4]}>
-        <T.ConeGeometry args={[4, 8, 3]} />
-        <T.MeshBasicMaterial color="#ffffff" transparent={true} {opacity} depthTest={false} />
-      </T.Mesh>
-
-      <!-- Label (if enabled and provided) -->
-      {#if props.showLabels && cursor.label}
-        <Text
-          text={cursor.label}
-          fontSize={14}
-          color={cursor.color}
-          anchorX="left"
-          anchorY="middle"
-          position={[15, 0, 0.02]}
-          outlineWidth={2}
-          outlineColor="#000000"
-          outlineOpacity={opacity}
-          fillOpacity={opacity}
-          layers={[SceneLayer.Overlay]}
+      <!-- Shadow (centered, no offset for top-down view) -->
+      <T.Mesh geometry={shadowGeometry} position={[0, 0, -0.01]}>
+        <T.MeshBasicMaterial
+          color="#000000"
+          transparent={true}
+          opacity={opacity * 0.25}
+          depthTest={false}
+          depthWrite={false}
+          side={2}
         />
-      {/if}
+      </T.Mesh>
+
+      <!-- White outline border -->
+      <T.Mesh geometry={cursorOutlineGeometry}>
+        <T.MeshBasicMaterial color="#ffffff" transparent={true} {opacity} depthTest={false} depthWrite={false} />
+      </T.Mesh>
+
+      <!-- Colored center circle -->
+      <T.Mesh geometry={cursorGeometry}>
+        <T.MeshBasicMaterial
+          color={cursor.color}
+          transparent={true}
+          opacity={opacity * 0.9}
+          depthTest={false}
+          depthWrite={false}
+        />
+      </T.Mesh>
     </T.Group>
   {/if}
 {/each}

--- a/packages/ui/src/lib/components/Stage/components/CursorLayer/index.ts
+++ b/packages/ui/src/lib/components/Stage/components/CursorLayer/index.ts
@@ -1,0 +1,2 @@
+export { default as CursorLayer } from './CursorLayer.svelte';
+export type { CursorData, CursorLayerProps } from './types';

--- a/packages/ui/src/lib/components/Stage/components/CursorLayer/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/CursorLayer/types.ts
@@ -1,0 +1,19 @@
+export interface CursorData {
+  id: string; // Unique identifier for the cursor (userId or sessionId)
+  worldPosition: {
+    x: number;
+    y: number;
+    z: number;
+  };
+  color: string;
+  label?: string;
+  opacity: number; // For fade-out effect
+  lastUpdateTime: number;
+}
+
+export interface CursorLayerProps {
+  cursors: CursorData[];
+  showLabels: boolean;
+  fadeOutDelay: number; // Time in ms before cursor starts fading
+  fadeOutDuration: number; // Time in ms for fade animation
+}

--- a/packages/ui/src/lib/components/Stage/components/CursorLayer/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/CursorLayer/types.ts
@@ -16,4 +16,8 @@ export interface CursorLayerProps {
   showLabels: boolean;
   fadeOutDelay: number; // Time in ms before cursor starts fading
   fadeOutDuration: number; // Time in ms for fade animation
+  gridSpacing?: number; // Grid spacing in inches (for sizing cursor)
+  displaySize?: { x: number; y: number }; // Display size in inches
+  displayResolution?: { x: number; y: number }; // Display resolution in pixels
+  sceneZoom?: number; // Current scene zoom level (to compensate for scaling)
 }

--- a/packages/ui/src/lib/components/Stage/components/FogOfWarLayer/FogOfWarMaterial.svelte
+++ b/packages/ui/src/lib/components/Stage/components/FogOfWarLayer/FogOfWarMaterial.svelte
@@ -54,10 +54,17 @@
     vertexShader: fogVertexShader
   });
 
+  // Track opacity separately to ensure it updates properly
+  let currentOpacity = $derived(stage.mode === StageMode.DM ? props.opacity.dm : props.opacity.player);
+
+  // Update opacity when it changes
+  $effect(() => {
+    fogMaterial.uniforms.uOpacity.value = currentOpacity;
+    fogMaterial.uniformsNeedUpdate = true;
+  });
+
   // Whenever the fog of war props change, we need to update the material
   $effect(() => {
-    fogMaterial.uniforms.uOpacity.value = stage.mode === StageMode.DM ? props.opacity.dm : props.opacity.player;
-
     fogMaterial.uniforms.uBaseColor.value = new THREE.Color(props.noise.baseColor);
     fogMaterial.uniforms.uFogColor1.value = new THREE.Color(props.noise.fogColor1);
     fogMaterial.uniforms.uFogColor2.value = new THREE.Color(props.noise.fogColor2);
@@ -81,6 +88,9 @@
     fogMaterial.uniforms.uClippingPlanes.value = clippingPlaneStore.value.map(
       (p) => new THREE.Vector4(p.normal.x, p.normal.y, p.normal.z, p.constant)
     );
+
+    // Force shader to update with new uniform values
+    fogMaterial.uniformsNeedUpdate = true;
   });
 
   useTask((delta) => {

--- a/packages/ui/src/lib/components/Stage/components/Scene/Scene.svelte
+++ b/packages/ui/src/lib/components/Stage/components/Scene/Scene.svelte
@@ -555,7 +555,11 @@
       cursors: cursors,
       showLabels: true,
       fadeOutDelay: 5000,
-      fadeOutDuration: 500
+      fadeOutDuration: 500,
+      gridSpacing: props.grid.spacing,
+      displaySize: props.display.size,
+      displayResolution: props.display.resolution,
+      sceneZoom: props.scene.zoom
     }}
   />
 </T.Object3D>

--- a/packages/ui/src/lib/components/Stage/components/Stage/Stage.svelte
+++ b/packages/ui/src/lib/components/Stage/components/Stage/Stage.svelte
@@ -6,6 +6,8 @@
   import { setContext } from 'svelte';
   import { PerfMonitor } from '@threlte/extras';
 
+  import type { CursorData } from './types';
+
   interface Props {
     props: StageProps;
     callbacks: Callbacks;
@@ -30,9 +32,11 @@
       snapToGrid?: boolean;
       enableDMG252?: boolean;
     } | null;
+    cursors?: CursorData[];
+    trackLocalCursor?: boolean;
   }
 
-  let { props, callbacks, receivedMeasurement = null }: Props = $props();
+  let { props, callbacks, receivedMeasurement = null, cursors = [], trackLocalCursor = false }: Props = $props();
 
   let sceneRef: SceneExports;
 
@@ -93,7 +97,7 @@
       <T.MeshBasicMaterial color={props.backgroundColor} />
     </T.Mesh>
 
-    <Scene bind:this={sceneRef} {props} {receivedMeasurement} />
+    <Scene bind:this={sceneRef} {props} {receivedMeasurement} {cursors} {trackLocalCursor} />
     {#if props.debug.enableStats}
       <PerfMonitor logsPerSecond={props.debug.loggingRate} anchorX={'right'} anchorY={'bottom'} />
     {/if}

--- a/packages/ui/src/lib/components/Stage/components/Stage/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/Stage/types.ts
@@ -8,6 +8,7 @@ import type { Marker, MarkerLayerProps } from '../MarkerLayer/types';
 import type { MeasurementLayerProps } from '../MeasurementLayer/types';
 import type { PostProcessingProps, SceneLayerProps } from '../Scene/types';
 import type { WeatherLayerProps } from '../WeatherLayer/types';
+export type { CursorData } from '../CursorLayer/types';
 
 export interface Callbacks {
   onAnnotationUpdate: (layerId: string, blob: Promise<Blob>) => void;
@@ -27,6 +28,7 @@ export interface Callbacks {
     type: number
   ) => void;
   onMeasurementEnd?: () => void;
+  onCursorMove?: (worldPosition: { x: number; y: number; z: number }) => void;
 }
 
 export enum StageMode {


### PR DESCRIPTION
Moves the cursor tracking and display away from DOM trigonometry to a native system in the Stage component. The player cursors are now rendered natively in the Three JS scene. This should be a significant performance improvement.

Also, fog opacity updates should now be a little more reliable.