### PR TITLE
Move fog and annotation system to store RLE data

### DIFF
--- a/apps/web/src/lib/db/app/migrations/0033_rle-mask.sql
+++ b/apps/web/src/lib/db/app/migrations/0033_rle-mask.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `annotations` ADD `mask` text;--> statement-breakpoint
+ALTER TABLE `scene` ADD `fog_of_war_mask` text;

--- a/apps/web/src/lib/db/app/migrations/meta/0033_snapshot.json
+++ b/apps/web/src/lib/db/app/migrations/meta/0033_snapshot.json
@@ -1,0 +1,1832 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f09b0f24-6f79-415e-bbdb-5efccaf47141",
+  "prevId": "50461856-a291-4be1-a4ac-91645b346c6f",
+  "tables": {
+    "annotations": {
+      "name": "annotations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'New Annotation'"
+        },
+        "opacity": {
+          "name": "opacity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#FF0000'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mask": {
+          "name": "mask",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_annotations_scene_id": {
+          "name": "idx_annotations_scene_id",
+          "columns": ["scene_id"],
+          "isUnique": false
+        },
+        "idx_annotations_order": {
+          "name": "idx_annotations_order",
+          "columns": ["scene_id", "order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "annotations_scene_id_scene_id_fk": {
+          "name": "annotations_scene_id_scene_id_fk",
+          "tableFrom": "annotations",
+          "tableTo": "scene",
+          "columnsFrom": ["scene_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "protected_annotation_opacity": {
+          "name": "protected_annotation_opacity",
+          "value": "\"annotations\".\"opacity\" >= 0 AND \"annotations\".\"opacity\" <= 1"
+        },
+        "protected_annotation_visibility": {
+          "name": "protected_annotation_visibility",
+          "value": "\"annotations\".\"visibility\" >= 0 AND \"annotations\".\"visibility\" <= 1"
+        }
+      }
+    },
+    "email_verification_codes": {
+      "name": "email_verification_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') + 60 * 15)"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_unique": {
+          "name": "email_verification_codes_user_id_unique",
+          "columns": ["user_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_users_id_fk": {
+          "name": "email_verification_codes_user_id_users_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "files": {
+      "name": "files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "files_location_unique": {
+          "name": "files_location_unique",
+          "columns": ["location"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_session": {
+      "name": "game_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "party_id": {
+          "name": "party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "unique_party_name": {
+          "name": "unique_party_name",
+          "columns": ["party_id", "slug"],
+          "isUnique": true
+        },
+        "idx_game_session_party_id": {
+          "name": "idx_game_session_party_id",
+          "columns": ["party_id"],
+          "isUnique": false
+        },
+        "idx_game_session_last_updated": {
+          "name": "idx_game_session_last_updated",
+          "columns": ["last_updated"],
+          "isUnique": false
+        },
+        "idx_game_session_slug": {
+          "name": "idx_game_session_slug",
+          "columns": ["slug"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "game_session_party_id_party_id_fk": {
+          "name": "game_session_party_id_party_id_fk",
+          "tableFrom": "game_session",
+          "tableTo": "party",
+          "columnsFrom": ["party_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "marker": {
+      "name": "marker",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'New token'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_location": {
+          "name": "image_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_scale": {
+          "name": "image_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "position_x": {
+          "name": "position_x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "position_y": {
+          "name": "position_y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "shape": {
+          "name": "shape",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "shape_color": {
+          "name": "shape_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#ffffff'"
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_marker_scene_id": {
+          "name": "idx_marker_scene_id",
+          "columns": ["scene_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "marker_scene_id_scene_id_fk": {
+          "name": "marker_scene_id_scene_id_fk",
+          "tableFrom": "marker",
+          "tableTo": "scene",
+          "columnsFrom": ["scene_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "protected_marker_visibility": {
+          "name": "protected_marker_visibility",
+          "value": "\"marker\".\"visibility\" >= 0 AND \"marker\".\"visibility\" <= 2"
+        },
+        "protected_marker_shape": {
+          "name": "protected_marker_shape",
+          "value": "\"marker\".\"shape\" >= 0 AND \"marker\".\"shape\" <= 3"
+        },
+        "protected_marker_size": {
+          "name": "protected_marker_size",
+          "value": "\"marker\".\"size\" >= 1 AND \"marker\".\"size\" <= 3"
+        }
+      }
+    },
+    "party_invite": {
+      "name": "party_invite",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "party_id": {
+          "name": "party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "party_invite_code_unique": {
+          "name": "party_invite_code_unique",
+          "columns": ["code"],
+          "isUnique": true
+        },
+        "idx_party_invite_party_id": {
+          "name": "idx_party_invite_party_id",
+          "columns": ["party_id"],
+          "isUnique": false
+        },
+        "idx_party_invite_email": {
+          "name": "idx_party_invite_email",
+          "columns": ["email"],
+          "isUnique": false
+        },
+        "idx_party_invite_code": {
+          "name": "idx_party_invite_code",
+          "columns": ["code"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "party_invite_party_id_party_id_fk": {
+          "name": "party_invite_party_id_party_id_fk",
+          "tableFrom": "party_invite",
+          "tableTo": "party",
+          "columnsFrom": ["party_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "party_invite_invited_by_users_id_fk": {
+          "name": "party_invite_invited_by_users_id_fk",
+          "tableFrom": "party_invite",
+          "tableTo": "users",
+          "columnsFrom": ["invited_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "party_member": {
+      "name": "party_member",
+      "columns": {
+        "party_id": {
+          "name": "party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_party_member_party_id": {
+          "name": "idx_party_member_party_id",
+          "columns": ["party_id"],
+          "isUnique": false
+        },
+        "idx_party_member_user_id": {
+          "name": "idx_party_member_user_id",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "idx_party_member_party_role": {
+          "name": "idx_party_member_party_role",
+          "columns": ["party_id", "role"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "party_member_party_id_party_id_fk": {
+          "name": "party_member_party_id_party_id_fk",
+          "tableFrom": "party_member",
+          "tableTo": "party",
+          "columnsFrom": ["party_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "party_member_user_id_users_id_fk": {
+          "name": "party_member_user_id_users_id_fk",
+          "tableFrom": "party_member",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "id": {
+          "columns": ["party_id", "user_id"],
+          "name": "id"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "party": {
+      "name": "party",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_file_id": {
+          "name": "avatar_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "pause_screen_file_id": {
+          "name": "pause_screen_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "active_scene_id": {
+          "name": "active_scene_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_paused": {
+          "name": "is_paused",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "tv_size": {
+          "name": "tv_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 40
+        },
+        "default_grid_type": {
+          "name": "default_grid_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "default_display_size_x": {
+          "name": "default_display_size_x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 17.77
+        },
+        "default_display_size_y": {
+          "name": "default_display_size_y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "default_resolution_x": {
+          "name": "default_resolution_x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1920
+        },
+        "default_resolution_y": {
+          "name": "default_resolution_y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1080
+        },
+        "default_display_padding_x": {
+          "name": "default_display_padding_x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 16
+        },
+        "default_display_padding_y": {
+          "name": "default_display_padding_y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 16
+        },
+        "default_grid_spacing": {
+          "name": "default_grid_spacing",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "default_line_thickness": {
+          "name": "default_line_thickness",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "plan_next_billing_date": {
+          "name": "plan_next_billing_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plan_expiration_date": {
+          "name": "plan_expiration_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plan_status": {
+          "name": "plan_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lemon_squeezy_customer_id": {
+          "name": "lemon_squeezy_customer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'free'"
+        }
+      },
+      "indexes": {
+        "party_name_unique": {
+          "name": "party_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "party_slug_unique": {
+          "name": "party_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        },
+        "idx_party_slug": {
+          "name": "idx_party_slug",
+          "columns": ["slug"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "party_avatar_file_id_files_id_fk": {
+          "name": "party_avatar_file_id_files_id_fk",
+          "tableFrom": "party",
+          "tableTo": "files",
+          "columnsFrom": ["avatar_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "party_pause_screen_file_id_files_id_fk": {
+          "name": "party_pause_screen_file_id_files_id_fk",
+          "tableFrom": "party",
+          "tableTo": "files",
+          "columnsFrom": ["pause_screen_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "protected_slug_check": {
+          "name": "protected_slug_check",
+          "value": "slug NOT IN ('signup', 'login', 'forgot-password', 'reset-password', 'verify-email', 'accept-invite', 'api', 'invalidate-invite', 'logout', 'create-party', 'profile', 'test', 'api', 'healthcheck', 'help', 'tos', 'promo')"
+        }
+      }
+    },
+    "promo_redemptions": {
+      "name": "promo_redemptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "promo_id": {
+          "name": "promo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "party_id": {
+          "name": "party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "unique_promo_user": {
+          "name": "unique_promo_user",
+          "columns": ["promo_id", "user_id"],
+          "isUnique": true
+        },
+        "idx_promo_redemptions_promo_id": {
+          "name": "idx_promo_redemptions_promo_id",
+          "columns": ["promo_id"],
+          "isUnique": false
+        },
+        "idx_promo_redemptions_user_id": {
+          "name": "idx_promo_redemptions_user_id",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "idx_promo_redemptions_party_id": {
+          "name": "idx_promo_redemptions_party_id",
+          "columns": ["party_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "promo_redemptions_promo_id_promos_id_fk": {
+          "name": "promo_redemptions_promo_id_promos_id_fk",
+          "tableFrom": "promo_redemptions",
+          "tableTo": "promos",
+          "columnsFrom": ["promo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "promo_redemptions_user_id_users_id_fk": {
+          "name": "promo_redemptions_user_id_users_id_fk",
+          "tableFrom": "promo_redemptions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "promo_redemptions_party_id_party_id_fk": {
+          "name": "promo_redemptions_party_id_party_id_fk",
+          "tableFrom": "promo_redemptions",
+          "tableTo": "party",
+          "columnsFrom": ["party_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "promos": {
+      "name": "promos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "promos_key_unique": {
+          "name": "promos_key_unique",
+          "columns": ["key"],
+          "isUnique": true
+        },
+        "idx_promos_key": {
+          "name": "idx_promos_key",
+          "columns": ["key"],
+          "isUnique": false
+        },
+        "idx_promos_created_by": {
+          "name": "idx_promos_created_by",
+          "columns": ["created_by"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "promos_created_by_users_id_fk": {
+          "name": "promos_created_by_users_id_fk",
+          "tableFrom": "promos",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "valid_max_uses": {
+          "name": "valid_max_uses",
+          "value": "\"promos\".\"max_uses\" >= 1"
+        }
+      }
+    },
+    "reset_password_codes": {
+      "name": "reset_password_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') + 60 * 15)"
+        }
+      },
+      "indexes": {
+        "reset_password_codes_user_id_unique": {
+          "name": "reset_password_codes_user_id_unique",
+          "columns": ["user_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "reset_password_codes_user_id_users_id_fk": {
+          "name": "reset_password_codes_user_id_users_id_fk",
+          "tableFrom": "reset_password_codes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scene": {
+      "name": "scene",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'New Scene'"
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#0b0b0c'"
+        },
+        "display_padding_x": {
+          "name": "display_padding_x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 16
+        },
+        "display_padding_y": {
+          "name": "display_padding_y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 16
+        },
+        "display_size_x": {
+          "name": "display_size_x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 17.77
+        },
+        "display_size_y": {
+          "name": "display_size_y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "display_resolution_x": {
+          "name": "display_resolution_x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1920
+        },
+        "display_resolution_y": {
+          "name": "display_resolution_y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1080
+        },
+        "fog_of_war_url": {
+          "name": "fog_of_war_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fog_of_war_mask": {
+          "name": "fog_of_war_mask",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fog_of_war_color": {
+          "name": "fog_of_war_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#000'"
+        },
+        "fog_of_war_opacity_dm": {
+          "name": "fog_of_war_opacity_dm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.3
+        },
+        "fog_of_war_opacity_player": {
+          "name": "fog_of_war_opacity_player",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.9
+        },
+        "map_location": {
+          "name": "map_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "map_thumb_location": {
+          "name": "map_thumb_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "map_rotation": {
+          "name": "map_rotation",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "map_offset_x": {
+          "name": "map_offset_x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "map_offset_y": {
+          "name": "map_offset_y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "map_zoom": {
+          "name": "map_zoom",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "grid_type": {
+          "name": "grid_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "grid_spacing": {
+          "name": "grid_spacing",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "grid_opacity": {
+          "name": "grid_opacity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.8
+        },
+        "grid_line_color": {
+          "name": "grid_line_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#E6E6E6'"
+        },
+        "grid_line_thickness": {
+          "name": "grid_line_thickness",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "grid_shadow_color": {
+          "name": "grid_shadow_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#000000'"
+        },
+        "grid_shadow_spread": {
+          "name": "grid_shadow_spread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "grid_shadow_blur": {
+          "name": "grid_shadow_blur",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "grid_shadow_opacity": {
+          "name": "grid_shadow_opacity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.4
+        },
+        "scene_offset_x": {
+          "name": "scene_offset_x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "scene_offset_y": {
+          "name": "scene_offset_y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "scene_rotation": {
+          "name": "scene_rotation",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "weather_fov": {
+          "name": "weather_fov",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "weather_intensity": {
+          "name": "weather_intensity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "weather_opacity": {
+          "name": "weather_opacity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "weather_type": {
+          "name": "weather_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "fog_enabled": {
+          "name": "fog_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "fog_color": {
+          "name": "fog_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#a0a0a0'"
+        },
+        "fog_opacity": {
+          "name": "fog_opacity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.8
+        },
+        "edge_enabled": {
+          "name": "edge_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "edge_url": {
+          "name": "edge_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "edge_opacity": {
+          "name": "edge_opacity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.3
+        },
+        "edge_scale": {
+          "name": "edge_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "edge_fade_start": {
+          "name": "edge_fade_start",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.2
+        },
+        "edge_fade_end": {
+          "name": "edge_fade_end",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "effects_enabled": {
+          "name": "effects_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "effects_bloom_intensity": {
+          "name": "effects_bloom_intensity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "effects_bloom_threshold": {
+          "name": "effects_bloom_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "effects_bloom_smoothing": {
+          "name": "effects_bloom_smoothing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.3
+        },
+        "effects_bloom_radius": {
+          "name": "effects_bloom_radius",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "effects_bloom_levels": {
+          "name": "effects_bloom_levels",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "effects_bloom_mip_map_blur": {
+          "name": "effects_bloom_mip_map_blur",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "effects_chromatic_aberration_intensity": {
+          "name": "effects_chromatic_aberration_intensity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "effects_lut_url": {
+          "name": "effects_lut_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effects_tone_mapping_mode": {
+          "name": "effects_tone_mapping_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "marker_stroke_color": {
+          "name": "marker_stroke_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#000000'"
+        },
+        "marker_stroke_width": {
+          "name": "marker_stroke_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 50
+        },
+        "marker_text_color": {
+          "name": "marker_text_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#ffffff'"
+        },
+        "marker_text_stroke_color": {
+          "name": "marker_text_stroke_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#000000'"
+        },
+        "annotation_layers": {
+          "name": "annotation_layers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "unique_session_scene_order": {
+          "name": "unique_session_scene_order",
+          "columns": ["session_id", "order"],
+          "isUnique": true
+        },
+        "idx_scene_order": {
+          "name": "idx_scene_order",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "idx_scene_game_session_id": {
+          "name": "idx_scene_game_session_id",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scene_session_id_game_session_id_fk": {
+          "name": "scene_session_id_game_session_id_fk",
+          "tableFrom": "scene",
+          "tableTo": "game_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "protected_fog_of_war_opacity_dm": {
+          "name": "protected_fog_of_war_opacity_dm",
+          "value": "\"scene\".\"fog_of_war_opacity_dm\" >= 0 AND \"scene\".\"fog_of_war_opacity_dm\" <= 1"
+        },
+        "protected_fog_of_war_opacity_player": {
+          "name": "protected_fog_of_war_opacity_player",
+          "value": "\"scene\".\"fog_of_war_opacity_player\" >= 0 AND \"scene\".\"fog_of_war_opacity_player\" <= 1"
+        },
+        "protected_grid_opacity": {
+          "name": "protected_grid_opacity",
+          "value": "\"scene\".\"grid_opacity\" >= 0 AND \"scene\".\"grid_opacity\" <= 1"
+        },
+        "protected_weather_intensity": {
+          "name": "protected_weather_intensity",
+          "value": "\"scene\".\"weather_intensity\" >= 0 AND \"scene\".\"weather_intensity\" <= 1"
+        },
+        "protected_weather_opacity": {
+          "name": "protected_weather_opacity",
+          "value": "\"scene\".\"weather_opacity\" >= 0 AND \"scene\".\"weather_opacity\" <= 1"
+        },
+        "protected_fog_opacity": {
+          "name": "protected_fog_opacity",
+          "value": "\"scene\".\"fog_opacity\" >= 0 AND \"scene\".\"fog_opacity\" <= 1"
+        },
+        "protected_edge_opacity": {
+          "name": "protected_edge_opacity",
+          "value": "\"scene\".\"edge_opacity\" >= 0 AND \"scene\".\"edge_opacity\" <= 1"
+        },
+        "protected_edge_fade_start": {
+          "name": "protected_edge_fade_start",
+          "value": "\"scene\".\"edge_fade_start\" >= 0 AND \"scene\".\"edge_fade_start\" <= 1"
+        },
+        "protected_edge_fade_end": {
+          "name": "protected_edge_fade_end",
+          "value": "\"scene\".\"edge_fade_end\" >= 0 AND \"scene\".\"edge_fade_end\" <= 1"
+        }
+      }
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_session_user_id": {
+          "name": "idx_session_user_id",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_users_id_fk": {
+          "name": "session_user_id_users_id_fk",
+          "tableFrom": "session",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_files": {
+      "name": "user_files",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_files_user_id": {
+          "name": "idx_user_files_user_id",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "idx_user_files_file_id": {
+          "name": "idx_user_files_file_id",
+          "columns": ["file_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_files_user_id_users_id_fk": {
+          "name": "user_files_user_id_users_id_fk",
+          "tableFrom": "user_files",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_files_file_id_files_id_fk": {
+          "name": "user_files_file_id_files_id_fk",
+          "tableFrom": "user_files",
+          "tableTo": "files",
+          "columnsFrom": ["file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "id": {
+          "columns": ["user_id", "file_id"],
+          "name": "id"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_file_id": {
+          "name": "avatar_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "favorite_party": {
+          "name": "favorite_party",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        },
+        "users_google_id_unique": {
+          "name": "users_google_id_unique",
+          "columns": ["google_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "users_avatar_file_id_files_id_fk": {
+          "name": "users_avatar_file_id_files_id_fk",
+          "tableFrom": "users",
+          "tableTo": "files",
+          "columnsFrom": ["avatar_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_favorite_party_party_id_fk": {
+          "name": "users_favorite_party_party_id_fk",
+          "tableFrom": "users",
+          "tableTo": "party",
+          "columnsFrom": ["favorite_party"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/web/src/lib/db/app/migrations/meta/_journal.json
+++ b/apps/web/src/lib/db/app/migrations/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1757731407357,
       "tag": "0032_player-fog",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "6",
+      "when": 1757908906480,
+      "tag": "0033_rle-mask",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/lib/db/app/schema.ts
+++ b/apps/web/src/lib/db/app/schema.ts
@@ -342,6 +342,7 @@ export const sceneTable = sqliteTable(
     displayResolutionX: integer('display_resolution_x').notNull().default(1920),
     displayResolutionY: integer('display_resolution_y').notNull().default(1080),
     fogOfWarUrl: text('fog_of_war_url'),
+    fogOfWarMask: text('fog_of_war_mask'), // Base64-encoded RLE mask data
     fogOfWarColor: text('fog_of_war_color').notNull().default('#000'),
     fogOfWarOpacityDm: real('fog_of_war_opacity_dm').notNull().default(0.3),
     fogOfWarOpacityPlayer: real('fog_of_war_opacity_player').notNull().default(0.9),
@@ -476,6 +477,7 @@ export const annotationsTable = sqliteTable(
     opacity: real('opacity').notNull().default(1.0),
     color: text('color').notNull().default('#FF0000'),
     url: text('url'), // S3/R2 storage for the drawn texture
+    mask: text('mask'), // Base64-encoded RLE mask data
     visibility: integer('visibility').notNull().default(1), // StageMode enum (0=DM, 1=Player)
     order: integer('order').notNull().default(0) // For layer ordering
   },

--- a/apps/web/src/lib/queries/index.ts
+++ b/apps/web/src/lib/queries/index.ts
@@ -4,6 +4,7 @@ export * from './email';
 export * from './file';
 export * from './gameSessions';
 export * from './markers';
+export * from './masks';
 export * from './parties';
 export * from './partyInvites';
 export * from './partyMembers';

--- a/apps/web/src/lib/queries/masks.ts
+++ b/apps/web/src/lib/queries/masks.ts
@@ -72,7 +72,7 @@ export const useFogMaskQuery = (sceneId: string | undefined) => {
         throw new Error('Failed to fetch fog mask');
       }
 
-      const data = await response.json();
+      const data = (await response.json()) as { maskData?: string };
 
       // Convert base64 back to Uint8Array if mask data exists
       if (data.maskData) {
@@ -87,5 +87,38 @@ export const useFogMaskQuery = (sceneId: string | undefined) => {
       return null;
     },
     enabled: !!sceneId
+  });
+};
+
+/**
+ * Fetches the annotation mask data for an annotation
+ */
+export const useAnnotationMaskQuery = (annotationId: string | undefined) => {
+  return createQuery({
+    queryKey: ['annotationMask', annotationId],
+    queryFn: async () => {
+      if (!annotationId) return null;
+
+      const response = await fetch(`/api/annotations/getMask?annotationId=${annotationId}`);
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch annotation mask');
+      }
+
+      const data = (await response.json()) as { maskData?: string };
+
+      // Convert base64 back to Uint8Array if mask data exists
+      if (data.maskData) {
+        const binaryString = atob(data.maskData);
+        const bytes = new Uint8Array(binaryString.length);
+        for (let i = 0; i < binaryString.length; i++) {
+          bytes[i] = binaryString.charCodeAt(i);
+        }
+        return bytes;
+      }
+
+      return null;
+    },
+    enabled: !!annotationId
   });
 };

--- a/apps/web/src/lib/queries/masks.ts
+++ b/apps/web/src/lib/queries/masks.ts
@@ -1,0 +1,91 @@
+import { mutationFactory } from '$lib/factories';
+import { createQuery } from '@tanstack/svelte-query';
+
+/**
+ * Updates the fog of war mask for a scene with RLE data
+ */
+export const useUpdateFogMaskMutation = () => {
+  return mutationFactory<{ sceneId: string; partyId: string; maskData: Uint8Array }, { success: boolean }, Error>({
+    mutationKey: ['updateFogMask'],
+    mutationFn: async ({ sceneId, partyId, maskData }) => {
+      // Convert Uint8Array to regular array for JSON serialization
+      const response = await fetch('/api/scenes/updateFogMask', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sceneId,
+          partyId,
+          maskData: Array.from(maskData)
+        })
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        console.error('Fog mask update failed:', errorText);
+        throw new Error(`Failed to update fog mask: ${errorText}`);
+      }
+
+      return response.json();
+    }
+  });
+};
+
+/**
+ * Updates the annotation mask with RLE data
+ */
+export const useUpdateAnnotationMaskMutation = () => {
+  return mutationFactory<{ annotationId: string; partyId: string; maskData: Uint8Array }, { success: boolean }, Error>({
+    mutationKey: ['updateAnnotationMask'],
+    mutationFn: async ({ annotationId, partyId, maskData }) => {
+      // Convert Uint8Array to regular array for JSON serialization
+      const response = await fetch('/api/annotations/updateMask', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          annotationId,
+          partyId,
+          maskData: Array.from(maskData)
+        })
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to update annotation mask');
+      }
+
+      return response.json();
+    }
+  });
+};
+
+/**
+ * Fetches the fog mask data for a scene
+ */
+export const useFogMaskQuery = (sceneId: string | undefined) => {
+  return createQuery({
+    queryKey: ['fogMask', sceneId],
+    queryFn: async () => {
+      if (!sceneId) return null;
+
+      const response = await fetch(`/api/scenes/getFogMask?sceneId=${sceneId}`);
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch fog mask');
+      }
+
+      const data = await response.json();
+
+      // Convert base64 back to Uint8Array if mask data exists
+      if (data.maskData) {
+        const binaryString = atob(data.maskData);
+        const bytes = new Uint8Array(binaryString.length);
+        for (let i = 0; i < binaryString.length; i++) {
+          bytes[i] = binaryString.charCodeAt(i);
+        }
+        return bytes;
+      }
+
+      return null;
+    },
+    enabled: !!sceneId
+  });
+};

--- a/apps/web/src/lib/server/scene/index.ts
+++ b/apps/web/src/lib/server/scene/index.ts
@@ -96,6 +96,11 @@ export const getScene = async (sceneId: string): Promise<SelectScene | (SelectSc
     throw new Error('Scene not found');
   }
 
+  // Remove fogOfWarMask if present to avoid serialization issues
+  if ('fogOfWarMask' in scene) {
+    delete (scene as any).fogOfWarMask;
+  }
+
   if (!scene?.mapLocation) {
     return scene;
   }
@@ -110,6 +115,21 @@ export const getScene = async (sceneId: string): Promise<SelectScene | (SelectSc
   const thumb = await transformImage(scene.mapLocation, 'w=3000,h=3000,fit=scale-down,gravity=center');
   const sceneWithThumb = { ...scene, thumb };
   return sceneWithThumb;
+};
+
+// New function to get only mask data for a scene
+export const getSceneMaskData = async (sceneId: string): Promise<{ fogOfWarMask: string | null }> => {
+  const result = await db
+    .select({ fogOfWarMask: sceneTable.fogOfWarMask })
+    .from(sceneTable)
+    .where(eq(sceneTable.id, sceneId))
+    .get();
+
+  if (!result) {
+    throw new Error('Scene not found');
+  }
+
+  return result;
 };
 
 export const getScenes = async (gameSessionId: string): Promise<(SelectScene | (SelectScene & Thumb))[]> => {
@@ -141,6 +161,11 @@ export const getScenes = async (gameSessionId: string): Promise<(SelectScene | (
   const scenesWithThumbs: (SelectScene | (SelectScene & Thumb))[] = [];
 
   for (const scene of scenes) {
+    // Remove fogOfWarMask if present to avoid serialization issues
+    if ('fogOfWarMask' in scene) {
+      delete (scene as any).fogOfWarMask;
+    }
+
     // Use mapThumbLocation if available, otherwise fall back to mapLocation
     const imageLocation = scene.mapThumbLocation || scene.mapLocation;
 
@@ -253,6 +278,11 @@ export const getSceneFromOrder = async (
     .get();
   if (!scene) {
     throw new Error('Scene not found');
+  }
+
+  // Remove fogOfWarMask if present to avoid serialization issues
+  if ('fogOfWarMask' in scene) {
+    delete (scene as any).fogOfWarMask;
   }
 
   let thumb = null;

--- a/apps/web/src/lib/utils/buildSceneProps.ts
+++ b/apps/web/src/lib/utils/buildSceneProps.ts
@@ -55,8 +55,8 @@ export const buildSceneProps = (
   let annotationLayers: AnnotationLayerData[] = [];
   if (activeSceneAnnotations && Array.isArray(activeSceneAnnotations)) {
     annotationLayers = activeSceneAnnotations
-      // Filter out player-only annotations for client mode
-      .filter((annotation) => mode === 'editor' || annotation.visibility === 0) // 0 = StageMode.DM (visible to all)
+      // Filter out DM-only annotations for client mode
+      .filter((annotation) => mode === 'editor' || annotation.visibility === 1) // 1 = StageMode.Player (visible to players)
       .map((annotation) => ({
         id: annotation.id,
         name: annotation.name,

--- a/apps/web/src/lib/utils/debug.ts
+++ b/apps/web/src/lib/utils/debug.ts
@@ -1,4 +1,4 @@
-import { dev } from '$app/environment';
+import { browser, dev } from '$app/environment';
 
 /**
  * Logs to console only in development mode
@@ -60,5 +60,23 @@ export function devError(...args: any[]) {
       }
     }
     console.error(...args);
+  }
+}
+
+/**
+ * Special timing log that can be enabled in production via query parameter
+ * Add ?debug=fogtiming to the URL to enable fog round-trip timing logs
+ * This has zero performance impact when not enabled
+ */
+export function timingLog(category: string, message: string): void {
+  if (!browser) return;
+
+  // Check if timing logs are enabled via query parameter
+  const urlParams = new URLSearchParams(window.location.search);
+  const debugParam = urlParams.get('debug');
+
+  // Only log if in dev mode OR if the specific debug flag is enabled
+  if (dev || debugParam === 'fogtiming') {
+    console.log(`[${category}] ${message}`);
   }
 }

--- a/apps/web/src/lib/utils/rle.ts
+++ b/apps/web/src/lib/utils/rle.ts
@@ -1,0 +1,217 @@
+/**
+ * Run-Length Encoding utilities for binary mask compression
+ * Optimized for fog and annotation layers
+ */
+
+/**
+ * Encodes a binary mask using Run-Length Encoding
+ * @param data - Binary mask data (Uint8Array where each byte is 0 or 255)
+ * @returns Encoded RLE data as Uint8Array
+ */
+export function encodeRLE(data: Uint8Array): Uint8Array {
+  if (data.length === 0) return new Uint8Array(0);
+
+  const runs: number[] = [];
+  let currentValue = data[0];
+  let runLength = 1;
+
+  // First byte indicates the starting value (0 or 1)
+  runs.push(currentValue === 0 ? 0 : 1);
+
+  for (let i = 1; i < data.length; i++) {
+    if (data[i] === currentValue) {
+      runLength++;
+    } else {
+      // Store the run length
+      pushVarint(runs, runLength);
+      currentValue = data[i];
+      runLength = 1;
+    }
+  }
+
+  // Don't forget the last run
+  pushVarint(runs, runLength);
+
+  return new Uint8Array(runs);
+}
+
+/**
+ * Decodes RLE data back to binary mask
+ * @param encoded - RLE encoded data
+ * @param targetLength - Expected length of decoded data
+ * @returns Decoded binary mask as Uint8Array
+ */
+export function decodeRLE(encoded: Uint8Array, targetLength: number): Uint8Array {
+  if (encoded.length === 0) return new Uint8Array(targetLength);
+
+  const result = new Uint8Array(targetLength);
+  let position = 0;
+  let index = 0;
+
+  // First byte indicates the starting value
+  const startValue = encoded[index++];
+  let currentValue = startValue === 0 ? 0 : 255;
+
+  while (index < encoded.length && position < targetLength) {
+    const [runLength, newIndex] = readVarint(encoded, index);
+    index = newIndex;
+
+    // Fill the result array with the current value
+    const end = Math.min(position + runLength, targetLength);
+    for (let i = position; i < end; i++) {
+      result[i] = currentValue;
+    }
+
+    position = end;
+    // Toggle the current value
+    currentValue = currentValue === 0 ? 255 : 0;
+  }
+
+  return result;
+}
+
+/**
+ * Variable-length integer encoding (for efficient storage of run lengths)
+ * Uses continuation bit in MSB
+ */
+function pushVarint(array: number[], value: number): void {
+  while (value > 127) {
+    array.push((value & 0x7f) | 0x80);
+    value >>>= 7;
+  }
+  array.push(value & 0x7f);
+}
+
+/**
+ * Read a variable-length integer from the array
+ */
+function readVarint(array: Uint8Array, index: number): [number, number] {
+  let value = 0;
+  let shift = 0;
+
+  while (index < array.length) {
+    const byte = array[index++];
+    value |= (byte & 0x7f) << shift;
+    if ((byte & 0x80) === 0) {
+      break;
+    }
+    shift += 7;
+  }
+
+  return [value, index];
+}
+
+/**
+ * Converts a PNG blob to RLE encoded data
+ * @param blob - PNG image blob
+ * @param width - Image width
+ * @param height - Image height
+ * @returns RLE encoded data
+ */
+export async function pngToRLE(blob: Blob, width: number, height: number): Promise<Uint8Array> {
+  // Create an off-screen canvas
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+
+  if (!ctx) {
+    throw new Error('Failed to get canvas context');
+  }
+
+  // Load the image
+  const img = new Image();
+  const url = URL.createObjectURL(blob);
+
+  try {
+    await new Promise((resolve, reject) => {
+      img.onload = resolve;
+      img.onerror = reject;
+      img.src = url;
+    });
+
+    // Draw image to canvas
+    ctx.drawImage(img, 0, 0, width, height);
+
+    // Get image data
+    const imageData = ctx.getImageData(0, 0, width, height);
+    const pixels = imageData.data;
+
+    // Convert RGBA to binary (using alpha channel)
+    const binaryData = new Uint8Array(width * height);
+    for (let i = 0; i < binaryData.length; i++) {
+      // Use alpha channel (every 4th byte starting at index 3)
+      binaryData[i] = pixels[i * 4 + 3] > 127 ? 255 : 0;
+    }
+
+    // Encode to RLE
+    return encodeRLE(binaryData);
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+/**
+ * Converts RLE encoded data to a PNG blob
+ * @param rleData - RLE encoded data
+ * @param width - Image width
+ * @param height - Image height
+ * @returns PNG image blob
+ */
+export async function rleToPng(rleData: Uint8Array, width: number, height: number): Promise<Blob> {
+  // Decode RLE to binary
+  const binaryData = decodeRLE(rleData, width * height);
+
+  // Create canvas
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+
+  if (!ctx) {
+    throw new Error('Failed to get canvas context');
+  }
+
+  // Create image data
+  const imageData = ctx.createImageData(width, height);
+  const pixels = imageData.data;
+
+  // Convert binary to RGBA
+  for (let i = 0; i < binaryData.length; i++) {
+    const idx = i * 4;
+    const value = binaryData[i];
+    pixels[idx] = 0; // R
+    pixels[idx + 1] = 0; // G
+    pixels[idx + 2] = 0; // B
+    pixels[idx + 3] = value; // A (0 or 255)
+  }
+
+  // Put image data to canvas
+  ctx.putImageData(imageData, 0, 0);
+
+  // Convert to blob
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) {
+        resolve(blob);
+      } else {
+        reject(new Error('Failed to convert canvas to blob'));
+      }
+    }, 'image/png');
+  });
+}
+
+/**
+ * Gets the size of RLE data when encoded
+ */
+export function getRLESize(data: Uint8Array): number {
+  return encodeRLE(data).length;
+}
+
+/**
+ * Estimates compression ratio for RLE encoding
+ */
+export function estimateCompressionRatio(data: Uint8Array): number {
+  const encoded = encodeRLE(data);
+  return data.length / encoded.length;
+}

--- a/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.server.ts
+++ b/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.server.ts
@@ -1,7 +1,7 @@
 import type { SelectAnnotation, SelectMarker } from '$lib/db/app/schema';
 import { getMarkersForScene, type Thumb } from '$lib/server';
 import { getAnnotationsForScene } from '$lib/server/annotations';
-import { createScene, getSceneFromOrder, getScenes } from '$lib/server/scene';
+import { createScene, getSceneFromOrder, getSceneMaskData, getScenes } from '$lib/server/scene';
 import { getPreferenceServer } from '$lib/utils/gameSessionPreferences';
 import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
@@ -41,6 +41,15 @@ export const load: PageServerLoad = async ({ parent, params, url, cookies }) => 
   const selectedScene = await getSceneFromOrder(gameSession.id, selectedSceneNumber);
   const selectedSceneMarkers = await getMarkersForScene(selectedScene.id);
   const selectedSceneAnnotations = await getAnnotationsForScene(selectedScene.id);
+
+  // Get fog mask data separately
+  let selectedSceneFogMask: string | null = null;
+  try {
+    const maskData = await getSceneMaskData(selectedScene.id);
+    selectedSceneFogMask = maskData.fogOfWarMask;
+  } catch (error) {
+    // Silently ignore - scene might not have mask data yet
+  }
   let activeSceneMarkers: (SelectMarker & Partial<Thumb>)[] = [];
   let activeSceneAnnotations: SelectAnnotation[] = [];
   if (activeScene) {
@@ -59,6 +68,7 @@ export const load: PageServerLoad = async ({ parent, params, url, cookies }) => 
     selectedScene,
     selectedSceneMarkers,
     selectedSceneAnnotations,
+    selectedSceneFogMask,
     activeScene,
     activeSceneMarkers,
     activeSceneAnnotations,

--- a/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.server.ts
+++ b/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.server.ts
@@ -1,6 +1,6 @@
 import type { SelectAnnotation, SelectMarker } from '$lib/db/app/schema';
 import { getMarkersForScene, type Thumb } from '$lib/server';
-import { getAnnotationsForScene } from '$lib/server/annotations';
+import { getAnnotationMaskData, getAnnotationsForScene } from '$lib/server/annotations';
 import { createScene, getSceneFromOrder, getSceneMaskData, getScenes } from '$lib/server/scene';
 import { getPreferenceServer } from '$lib/utils/gameSessionPreferences';
 import { redirect } from '@sveltejs/kit';
@@ -50,6 +50,17 @@ export const load: PageServerLoad = async ({ parent, params, url, cookies }) => 
   } catch (error) {
     // Silently ignore - scene might not have mask data yet
   }
+
+  // Get annotation mask data for all annotations
+  const selectedSceneAnnotationMasks: Record<string, string | null> = {};
+  try {
+    for (const annotation of selectedSceneAnnotations) {
+      const maskData = await getAnnotationMaskData(annotation.id);
+      selectedSceneAnnotationMasks[annotation.id] = maskData?.mask || null;
+    }
+  } catch (error) {
+    // Silently ignore - annotations might not have mask data yet
+  }
   let activeSceneMarkers: (SelectMarker & Partial<Thumb>)[] = [];
   let activeSceneAnnotations: SelectAnnotation[] = [];
   if (activeScene) {
@@ -68,6 +79,7 @@ export const load: PageServerLoad = async ({ parent, params, url, cookies }) => 
     selectedScene,
     selectedSceneMarkers,
     selectedSceneAnnotations,
+    selectedSceneAnnotationMasks,
     selectedSceneFogMask,
     activeScene,
     activeSceneMarkers,

--- a/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
+++ b/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
@@ -1817,12 +1817,13 @@
    */
   let isUpdatingFog = false;
   let pendingFogBlob: Blob | null = null;
+  let pendingFogUpdateId: string | null = null;
   let fogUploadAbortController: AbortController | null = null;
 
   const processFogUpdate = async () => {
     if (!pendingFogBlob || isSaving) return;
 
-    const updateId = pendingFogBlob['updateId'] || 'unknown';
+    const updateId = pendingFogUpdateId || 'unknown';
 
     // Check if user is still drawing
     if (stage?.fogOfWar?.isDrawing()) {
@@ -1833,6 +1834,7 @@
     }
 
     pendingFogBlob = null; // Clear pending blob
+    pendingFogUpdateId = null; // Clear update ID
 
     timingLog('FOG-RT', `${updateId} - 3. Starting RLE encoding at ${new Date().toISOString()}`);
     // Get RLE encoded data from the fog layer
@@ -1921,7 +1923,7 @@
     // Store a flag that we need to process fog update
     // We'll use RLE encoding instead of the blob
     pendingFogBlob = new Blob(); // Just use empty blob as a flag
-    pendingFogBlob['updateId'] = updateId; // Attach ID for tracking
+    pendingFogUpdateId = updateId; // Store ID separately
 
     // Clear any existing timer
     if (fogUpdateTimer) {

--- a/apps/web/src/routes/(app)/[party]/play/+page@.svelte
+++ b/apps/web/src/routes/(app)/[party]/play/+page@.svelte
@@ -534,8 +534,45 @@
     stageIsLoading = true;
   }
 
-  function onStageInitialized() {
+  async function onStageInitialized() {
     stageIsLoading = false;
+
+    // Load fog mask if available
+    if (data.activeSceneFogMask && stage?.fogOfWar?.fromRLE) {
+      try {
+        // Convert base64 back to Uint8Array
+        const binaryString = atob(data.activeSceneFogMask);
+        const bytes = new Uint8Array(binaryString.length);
+        for (let i = 0; i < binaryString.length; i++) {
+          bytes[i] = binaryString.charCodeAt(i);
+        }
+        // Apply the mask to the fog layer
+        await stage.fogOfWar.fromRLE(bytes, 1024, 1024);
+      } catch (error) {
+        console.error('Error loading fog mask:', error);
+      }
+    }
+
+    // Load annotation masks if available
+    if (data.activeSceneAnnotationMasks && stage?.annotations?.loadMask) {
+      try {
+        for (const [annotationId, maskData] of Object.entries(data.activeSceneAnnotationMasks)) {
+          if (maskData) {
+            // Convert base64 back to Uint8Array
+            const binaryString = atob(maskData);
+            const bytes = new Uint8Array(binaryString.length);
+            for (let i = 0; i < binaryString.length; i++) {
+              bytes[i] = binaryString.charCodeAt(i);
+            }
+            // Apply the mask to the annotation layer
+            await stage.annotations.loadMask(annotationId, bytes);
+          }
+        }
+      } catch (error) {
+        console.error('Error loading annotation masks:', error);
+      }
+    }
+
     // Immediately fit when stage is ready
     if (stage?.scene?.fit) {
       stage.scene.fit();

--- a/apps/web/src/routes/api/annotations/getMask/+server.ts
+++ b/apps/web/src/routes/api/annotations/getMask/+server.ts
@@ -1,0 +1,29 @@
+import { apiFactory } from '$lib/factories';
+import { getAnnotationMaskData } from '$lib/server/annotations';
+import { z } from 'zod';
+
+const validationSchema = z.object({
+  annotationId: z.string()
+});
+
+export const GET = apiFactory(
+  async ({ url }) => {
+    const annotationId = url.searchParams.get('annotationId');
+
+    if (!annotationId) {
+      throw new Error('Annotation ID is required');
+    }
+
+    const maskData = await getAnnotationMaskData(annotationId);
+
+    return {
+      maskData: maskData?.mask || null
+    };
+  },
+  {
+    validationSchema: z.object({}), // No body validation for GET
+    validationErrorMessage: 'Invalid annotation mask request',
+    unauthorizedMessage: 'You are not authorized to access this annotation mask.',
+    unexpectedErrorMessage: 'An unexpected error occurred while fetching the annotation mask.'
+  }
+);

--- a/apps/web/src/routes/api/annotations/updateMask/+server.ts
+++ b/apps/web/src/routes/api/annotations/updateMask/+server.ts
@@ -1,0 +1,65 @@
+import { db } from '$lib/db/app/index';
+import { annotationsTable, sceneTable } from '$lib/db/app/schema';
+import { apiFactory } from '$lib/factories';
+import { isUserInParty } from '$lib/server';
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+
+const validationSchema = z.object({
+  annotationId: z.string(),
+  partyId: z.string(),
+  maskData: z.instanceof(Uint8Array).or(z.array(z.number()).transform((arr) => new Uint8Array(arr)))
+});
+
+export const POST = apiFactory(
+  async ({ body, locals }) => {
+    const { annotationId, partyId, maskData } = body;
+
+    if (!locals.user?.id || !(await isUserInParty(locals.user.id, partyId))) {
+      throw new Error('Unauthorized');
+    }
+
+    // First check if annotation exists and user has access
+    const [annotation] = await db
+      .select({ sceneId: annotationsTable.sceneId })
+      .from(annotationsTable)
+      .where(eq(annotationsTable.id, annotationId))
+      .limit(1);
+
+    if (!annotation) {
+      throw new Error('Annotation not found');
+    }
+
+    // Verify the scene belongs to the party
+    const [scene] = await db
+      .select({ gameSessionId: sceneTable.gameSessionId })
+      .from(sceneTable)
+      .where(eq(sceneTable.id, annotation.sceneId))
+      .limit(1);
+
+    if (!scene) {
+      throw new Error('Scene not found');
+    }
+
+    // Convert Uint8Array to base64 string for storage
+    // This avoids blob serialization issues with Turso/LibSQL
+    const base64Data = Buffer.from(maskData).toString('base64');
+
+    // Update the annotation mask in the database
+    await db
+      .update(annotationsTable)
+      .set({
+        mask: base64Data,
+        url: null // Clear the old URL since we're using RLE now
+      })
+      .where(eq(annotationsTable.id, annotationId));
+
+    return { success: true };
+  },
+  {
+    validationSchema,
+    validationErrorMessage: 'Invalid annotation mask data',
+    unauthorizedMessage: 'You are not authorized to update this annotation.',
+    unexpectedErrorMessage: 'An unexpected error occurred while updating the annotation mask.'
+  }
+);

--- a/apps/web/src/routes/api/scenes/getFogMask/+server.ts
+++ b/apps/web/src/routes/api/scenes/getFogMask/+server.ts
@@ -1,0 +1,24 @@
+import { getSceneMaskData } from '$lib/server/scene';
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+
+export const GET: RequestHandler = async ({ url }) => {
+  try {
+    const sceneId = url.searchParams.get('sceneId');
+
+    if (!sceneId) {
+      return json({ success: false, error: 'Scene ID is required' }, { status: 400 });
+    }
+
+    const maskData = await getSceneMaskData(sceneId);
+
+    // Return the base64 mask data
+    return json({
+      success: true,
+      maskData: maskData.fogOfWarMask
+    });
+  } catch (error) {
+    console.error('Error fetching fog mask:', error);
+    return json({ success: false, error: 'Failed to fetch fog mask' }, { status: 500 });
+  }
+};

--- a/apps/web/src/routes/api/scenes/updateFogMask/+server.ts
+++ b/apps/web/src/routes/api/scenes/updateFogMask/+server.ts
@@ -1,0 +1,52 @@
+import { db } from '$lib/db/app/index';
+import { sceneTable } from '$lib/db/app/schema';
+import { apiFactory } from '$lib/factories';
+import { isUserInParty } from '$lib/server';
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+
+const validationSchema = z.object({
+  sceneId: z.string(),
+  partyId: z.string(),
+  maskData: z.instanceof(Uint8Array).or(z.array(z.number()).transform((arr) => new Uint8Array(arr)))
+});
+
+export const POST = apiFactory(
+  async ({ body, locals }) => {
+    const { sceneId, partyId, maskData } = body;
+
+    if (!locals.user?.id || !(await isUserInParty(locals.user.id, partyId))) {
+      throw new Error('Unauthorized');
+    }
+
+    // Update the fog mask in the database
+    // Convert Uint8Array to base64 string for storage
+    // This avoids blob serialization issues with Turso/LibSQL
+    const base64Data = Buffer.from(maskData).toString('base64');
+
+    try {
+      // Store as base64 text
+      const result = await db
+        .update(sceneTable)
+        .set({
+          fogOfWarMask: base64Data
+        })
+        .where(eq(sceneTable.id, sceneId))
+        .execute();
+    } catch (error) {
+      console.error('[FOG UPDATE] Database update error:', error);
+      console.error('[FOG UPDATE] Base64 length:', base64Data.length);
+      console.error('[FOG UPDATE] Scene ID:', sceneId);
+
+      throw new Error(`Database update failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    }
+
+    return { success: true };
+  },
+  {
+    validationSchema,
+    validationErrorMessage: 'Invalid fog mask data',
+    unauthorizedMessage: 'You are not authorized to update this scene.',
+    unexpectedErrorMessage: 'An unexpected error occurred while updating the fog mask.'
+  }
+);

--- a/packages/ui/src/lib/components/Stage/components/AnnotationLayer/AnnotationLayer.svelte
+++ b/packages/ui/src/lib/components/Stage/components/AnnotationLayer/AnnotationLayer.svelte
@@ -271,6 +271,18 @@
   export async function fromRLE(rleData: Uint8Array, width: number, height: number) {
     return activeLayer?.fromRLE(rleData, width, height);
   }
+
+  /**
+   * Loads RLE-encoded data into a specific annotation layer by ID
+   * @param layerId The ID of the annotation layer
+   * @param rleData RLE encoded data
+   */
+  export async function loadMask(layerId: string, rleData: Uint8Array) {
+    const layer = layers.find((layer) => layer.getId() === layerId);
+    if (layer) {
+      return layer.fromRLE(rleData, 1024, 1024);
+    }
+  }
 </script>
 
 <LayerInput

--- a/packages/ui/src/lib/components/Stage/components/AnnotationLayer/AnnotationLayer.svelte
+++ b/packages/ui/src/lib/components/Stage/components/AnnotationLayer/AnnotationLayer.svelte
@@ -253,6 +253,24 @@
     // For now, return the active layer's PNG or an empty blob
     return (await activeLayer?.toPng()) ?? new Blob();
   }
+
+  /**
+   * Exports the active annotation layer state as RLE-encoded data
+   * @returns RLE encoded Uint8Array
+   */
+  export async function toRLE(): Promise<Uint8Array> {
+    return (await activeLayer?.toRLE()) ?? new Uint8Array();
+  }
+
+  /**
+   * Loads RLE-encoded data into the active annotation layer
+   * @param rleData RLE encoded data
+   * @param width Image width
+   * @param height Image height
+   */
+  export async function fromRLE(rleData: Uint8Array, width: number, height: number) {
+    return activeLayer?.fromRLE(rleData, width, height);
+  }
 </script>
 
 <LayerInput

--- a/packages/ui/src/lib/components/Stage/components/AnnotationLayer/AnnotationMaterial.svelte
+++ b/packages/ui/src/lib/components/Stage/components/AnnotationLayer/AnnotationMaterial.svelte
@@ -94,6 +94,24 @@
   export async function toPng(): Promise<Blob> {
     return drawMaterial.toPng();
   }
+
+  /**
+   * Exports the annotation layer state as RLE-encoded data
+   * @returns RLE encoded Uint8Array
+   */
+  export async function toRLE(): Promise<Uint8Array> {
+    return drawMaterial.toRLE();
+  }
+
+  /**
+   * Loads RLE-encoded data into the annotation layer
+   * @param rleData RLE encoded data
+   * @param width Image width
+   * @param height Image height
+   */
+  export async function fromRLE(rleData: Uint8Array, width: number, height: number) {
+    return drawMaterial.fromRLE(rleData, width, height);
+  }
 </script>
 
 <DrawingMaterial

--- a/packages/ui/src/lib/components/Stage/components/AnnotationLayer/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/AnnotationLayer/types.ts
@@ -50,6 +50,11 @@ export interface AnnotationLayerData {
   url: string | null;
 
   /**
+   * Version timestamp for mask data changes (for real-time sync)
+   */
+  maskVersion?: number;
+
+  /**
    * Control who can see the layer
    */
   visibility: StageMode;

--- a/packages/ui/src/lib/components/Stage/components/AnnotationLayer/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/AnnotationLayer/types.ts
@@ -58,5 +58,7 @@ export interface AnnotationLayerData {
 export interface AnnotationExports {
   clear: (layerId: string) => void;
   toPng: () => Promise<Blob>;
+  toRLE: () => Promise<Uint8Array>;
+  fromRLE: (rleData: Uint8Array, width: number, height: number) => Promise<void>;
   isDrawing: () => boolean;
 }

--- a/packages/ui/src/lib/components/Stage/components/AnnotationLayer/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/AnnotationLayer/types.ts
@@ -60,5 +60,6 @@ export interface AnnotationExports {
   toPng: () => Promise<Blob>;
   toRLE: () => Promise<Uint8Array>;
   fromRLE: (rleData: Uint8Array, width: number, height: number) => Promise<void>;
+  loadMask: (layerId: string, rleData: Uint8Array) => Promise<void>;
   isDrawing: () => boolean;
 }

--- a/packages/ui/src/lib/components/Stage/components/DrawingLayer/DrawingMaterial.svelte
+++ b/packages/ui/src/lib/components/Stage/components/DrawingLayer/DrawingMaterial.svelte
@@ -323,14 +323,18 @@
     // Decode RLE to binary
     const binaryData = decodeRLE(actualRleData, actualWidth * actualHeight);
 
-    // Create texture from binary data
+    // Create texture from binary data - flip vertically to match WebGL coordinate system
     const rgba = new Uint8Array(actualWidth * actualHeight * 4);
-    for (let i = 0; i < binaryData.length; i++) {
-      const idx = i * 4;
-      rgba[idx] = 0; // R
-      rgba[idx + 1] = 0; // G
-      rgba[idx + 2] = 0; // B
-      rgba[idx + 3] = binaryData[i]; // A
+    for (let y = 0; y < actualHeight; y++) {
+      for (let x = 0; x < actualWidth; x++) {
+        const srcIndex = y * actualWidth + x;
+        const dstIndex = (actualHeight - 1 - y) * actualWidth + x; // Flip vertically
+        const idx = dstIndex * 4;
+        rgba[idx] = 0; // R
+        rgba[idx + 1] = 0; // G
+        rgba[idx + 2] = 0; // B
+        rgba[idx + 3] = binaryData[srcIndex]; // A
+      }
     }
 
     // Create texture

--- a/packages/ui/src/lib/components/Stage/components/DrawingLayer/DrawingMaterial.svelte
+++ b/packages/ui/src/lib/components/Stage/components/DrawingLayer/DrawingMaterial.svelte
@@ -5,6 +5,7 @@
   import { onDestroy, untrack } from 'svelte';
   import type { Size } from '../../types';
   import { RenderMode } from './types';
+  import { encodeRLE, decodeRLE, pngToRLE, rleToPng } from '../../../../utils/rle';
 
   import drawVertexShader from '../../shaders/Drawing.vert?raw';
   import drawFragmentShader from '../../shaders/Drawing.frag?raw';
@@ -255,6 +256,89 @@
     return new Promise((resolve) => {
       flippedCanvas.toBlob((blob) => resolve(blob!), 'image/png');
     });
+  }
+
+  /**
+   * Exports the current state as RLE-encoded data
+   * @returns RLE encoded Uint8Array with dimensions prepended
+   */
+  export async function toRLE(): Promise<Uint8Array> {
+    const width = persistedTarget.width;
+    const height = persistedTarget.height;
+
+    // Read pixels from WebGL render target
+    const pixels = new Uint8Array(4 * width * height);
+    renderer.readRenderTargetPixels(persistedTarget, 0, 0, width, height, pixels);
+
+    // Extract alpha channel and flip vertically
+    const binaryData = new Uint8Array(width * height);
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const srcIndex = (y * width + x) * 4 + 3; // Alpha channel
+        const dstIndex = (height - 1 - y) * width + x; // Flip vertically
+        binaryData[dstIndex] = pixels[srcIndex] > 127 ? 255 : 0;
+      }
+    }
+
+    const rleData = encodeRLE(binaryData);
+
+    // Prepend dimensions to the RLE data (4 bytes for width, 4 bytes for height)
+    const result = new Uint8Array(8 + rleData.length);
+    const view = new DataView(result.buffer);
+    view.setUint32(0, width, true); // little-endian
+    view.setUint32(4, height, true); // little-endian
+    result.set(rleData, 8);
+
+    return result;
+  }
+
+  /**
+   * Loads RLE-encoded data into the drawing buffer
+   * @param rleData RLE encoded data (with dimensions prepended)
+   * @param width Image width (ignored if dimensions are in data)
+   * @param height Image height (ignored if dimensions are in data)
+   */
+  export async function fromRLE(rleData: Uint8Array, width?: number, height?: number) {
+    // Check if dimensions are prepended (new format)
+    let actualWidth = width || 1024;
+    let actualHeight = height || 1024;
+    let rleStart = 0;
+
+    if (rleData.length > 8) {
+      const view = new DataView(rleData.buffer, rleData.byteOffset, rleData.byteLength);
+      const possibleWidth = view.getUint32(0, true);
+      const possibleHeight = view.getUint32(4, true);
+
+      // Sanity check - dimensions should be reasonable
+      if (possibleWidth > 0 && possibleWidth <= 4096 && possibleHeight > 0 && possibleHeight <= 4096) {
+        actualWidth = possibleWidth;
+        actualHeight = possibleHeight;
+        rleStart = 8;
+      }
+    }
+
+    // Extract the actual RLE data
+    const actualRleData = rleStart > 0 ? rleData.slice(rleStart) : rleData;
+
+    // Decode RLE to binary
+    const binaryData = decodeRLE(actualRleData, actualWidth * actualHeight);
+
+    // Create texture from binary data
+    const rgba = new Uint8Array(actualWidth * actualHeight * 4);
+    for (let i = 0; i < binaryData.length; i++) {
+      const idx = i * 4;
+      rgba[idx] = 0; // R
+      rgba[idx + 1] = 0; // G
+      rgba[idx + 2] = 0; // B
+      rgba[idx + 3] = binaryData[i]; // A
+    }
+
+    // Create texture
+    const texture = new THREE.DataTexture(rgba, actualWidth, actualHeight, THREE.RGBAFormat);
+    texture.needsUpdate = true;
+
+    // Load into buffer
+    render(RenderMode.Revert, true, texture);
   }
 </script>
 

--- a/packages/ui/src/lib/components/Stage/components/DrawingLayer/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/DrawingLayer/types.ts
@@ -31,6 +31,11 @@ export interface DrawingLayerProps {
   url: string | null;
 
   /**
+   * Version timestamp for mask data changes (for real-time sync)
+   */
+  maskVersion?: number;
+
+  /**
    * The opacity of the drawing layer
    */
   opacity: {

--- a/packages/ui/src/lib/components/Stage/components/FogOfWarLayer/FogOfWarLayer.svelte
+++ b/packages/ui/src/lib/components/Stage/components/FogOfWarLayer/FogOfWarLayer.svelte
@@ -185,6 +185,24 @@
   export async function toPng(): Promise<Blob> {
     return (await material?.toPng()) ?? new Blob();
   }
+
+  /**
+   * Exports the fog of war state as RLE-encoded data
+   * @returns RLE encoded Uint8Array
+   */
+  export async function toRLE(): Promise<Uint8Array> {
+    return (await material?.toRLE()) ?? new Uint8Array();
+  }
+
+  /**
+   * Loads RLE-encoded data into the fog of war
+   * @param rleData RLE encoded data
+   * @param width Image width
+   * @param height Image height
+   */
+  export async function fromRLE(rleData: Uint8Array, width: number, height: number) {
+    return material?.fromRLE(rleData, width, height);
+  }
 </script>
 
 <LayerInput

--- a/packages/ui/src/lib/components/Stage/components/FogOfWarLayer/FogOfWarMaterial.svelte
+++ b/packages/ui/src/lib/components/Stage/components/FogOfWarLayer/FogOfWarMaterial.svelte
@@ -135,6 +135,24 @@
   export async function toPng(): Promise<Blob> {
     return drawMaterial.toPng();
   }
+
+  /**
+   * Exports the fog of war state as RLE-encoded data
+   * @returns RLE encoded Uint8Array
+   */
+  export async function toRLE(): Promise<Uint8Array> {
+    return drawMaterial.toRLE();
+  }
+
+  /**
+   * Loads RLE-encoded data into the fog of war
+   * @param rleData RLE encoded data
+   * @param width Image width
+   * @param height Image height
+   */
+  export async function fromRLE(rleData: Uint8Array, width: number, height: number) {
+    return drawMaterial.fromRLE(rleData, width, height);
+  }
 </script>
 
 <DrawingMaterial

--- a/packages/ui/src/lib/components/Stage/components/FogOfWarLayer/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/FogOfWarLayer/types.ts
@@ -110,5 +110,7 @@ export interface FogOfWarExports {
   clearFog: () => void;
   resetFog: () => void;
   toPng: () => Promise<Blob>;
+  toRLE: () => Promise<Uint8Array>;
+  fromRLE: (rleData: Uint8Array, width: number, height: number) => Promise<void>;
   isDrawing: () => boolean;
 }

--- a/packages/ui/src/lib/components/Stage/components/MapLayer/MapLayer.svelte
+++ b/packages/ui/src/lib/components/Stage/components/MapLayer/MapLayer.svelte
@@ -165,6 +165,8 @@
     clear: () => fogOfWarLayer.clearFog(),
     reset: () => fogOfWarLayer.resetFog(),
     toPng: () => fogOfWarLayer.toPng(),
+    toRLE: () => fogOfWarLayer.toRLE(),
+    fromRLE: (rleData: Uint8Array, width: number, height: number) => fogOfWarLayer.fromRLE(rleData, width, height),
     isDrawing: () => fogOfWarLayer?.isDrawing() ?? false
   };
 </script>

--- a/packages/ui/src/lib/components/Stage/components/MapLayer/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/MapLayer/types.ts
@@ -50,6 +50,8 @@ export interface MapLayerExports {
     clear: () => void;
     reset: () => void;
     toPng: () => Promise<Blob>;
+    toRLE: () => Promise<Uint8Array>;
+    fromRLE: (rleData: Uint8Array, width: number, height: number) => Promise<void>;
     isDrawing: () => boolean;
   };
 }

--- a/packages/ui/src/lib/components/Stage/components/Scene/Scene.svelte
+++ b/packages/ui/src/lib/components/Stage/components/Scene/Scene.svelte
@@ -430,6 +430,7 @@
     clear: (layerId: string) => annotationsLayer.clear(layerId),
     toRLE: () => annotationsLayer?.toRLE(),
     fromRLE: (rleData: Uint8Array, width: number, height: number) => annotationsLayer?.fromRLE(rleData, width, height),
+    loadMask: (layerId: string, rleData: Uint8Array) => annotationsLayer?.loadMask(layerId, rleData),
     isDrawing: () => annotationsLayer?.isDrawing() ?? false
   };
 

--- a/packages/ui/src/lib/components/Stage/components/Scene/Scene.svelte
+++ b/packages/ui/src/lib/components/Stage/components/Scene/Scene.svelte
@@ -428,6 +428,8 @@
 
   export const annotations = {
     clear: (layerId: string) => annotationsLayer.clear(layerId),
+    toRLE: () => annotationsLayer?.toRLE(),
+    fromRLE: (rleData: Uint8Array, width: number, height: number) => annotationsLayer?.fromRLE(rleData, width, height),
     isDrawing: () => annotationsLayer?.isDrawing() ?? false
   };
 
@@ -442,6 +444,8 @@
     clear: () => mapLayer.fogOfWar.clear(),
     reset: () => mapLayer.fogOfWar.reset(),
     toPng: () => mapLayer.fogOfWar.toPng(),
+    toRLE: () => mapLayer.fogOfWar.toRLE(),
+    fromRLE: (rleData: Uint8Array, width: number, height: number) => mapLayer.fogOfWar.fromRLE(rleData, width, height),
     isDrawing: () => mapLayer?.fogOfWar?.isDrawing() ?? false
   };
 

--- a/packages/ui/src/lib/components/Stage/components/Scene/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/Scene/types.ts
@@ -64,6 +64,7 @@ export interface SceneExports {
     clear: (layerId: string) => void;
     toRLE: () => Promise<Uint8Array>;
     fromRLE: (rleData: Uint8Array, width: number, height: number) => Promise<void>;
+    loadMask: (layerId: string, rleData: Uint8Array) => Promise<void>;
     isDrawing: () => boolean;
   };
 

--- a/packages/ui/src/lib/components/Stage/components/Scene/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/Scene/types.ts
@@ -62,6 +62,8 @@ export interface SceneExports {
 
   annotations: {
     clear: (layerId: string) => void;
+    toRLE: () => Promise<Uint8Array>;
+    fromRLE: (rleData: Uint8Array, width: number, height: number) => Promise<void>;
     isDrawing: () => boolean;
   };
 
@@ -69,6 +71,8 @@ export interface SceneExports {
     clear: () => void;
     reset: () => void;
     toPng: () => Promise<Blob>;
+    toRLE: () => Promise<Uint8Array>;
+    fromRLE: (rleData: Uint8Array, width: number, height: number) => Promise<void>;
     isDrawing: () => boolean;
   };
 

--- a/packages/ui/src/lib/components/Stage/components/Stage/Stage.svelte
+++ b/packages/ui/src/lib/components/Stage/components/Stage/Stage.svelte
@@ -52,6 +52,9 @@
 
   export const annotations = {
     clear: (layerId: string) => sceneRef.annotations.clear(layerId),
+    toRLE: () => sceneRef?.annotations?.toRLE(),
+    fromRLE: (rleData: Uint8Array, width: number, height: number) =>
+      sceneRef?.annotations?.fromRLE(rleData, width, height),
     isDrawing: () => sceneRef?.annotations?.isDrawing() ?? false
   };
 
@@ -64,6 +67,8 @@
     clear: () => sceneRef?.fogOfWar.clear(),
     reset: () => sceneRef?.fogOfWar.reset(),
     toPng: () => sceneRef?.fogOfWar.toPng(),
+    toRLE: () => sceneRef?.fogOfWar.toRLE(),
+    fromRLE: (rleData: Uint8Array, width: number, height: number) => sceneRef?.fogOfWar.fromRLE(rleData, width, height),
     isDrawing: () => sceneRef?.fogOfWar?.isDrawing() ?? false
   };
 

--- a/packages/ui/src/lib/components/Stage/components/Stage/Stage.svelte
+++ b/packages/ui/src/lib/components/Stage/components/Stage/Stage.svelte
@@ -55,6 +55,7 @@
     toRLE: () => sceneRef?.annotations?.toRLE(),
     fromRLE: (rleData: Uint8Array, width: number, height: number) =>
       sceneRef?.annotations?.fromRLE(rleData, width, height),
+    loadMask: (layerId: string, rleData: Uint8Array) => sceneRef?.annotations?.loadMask(layerId, rleData),
     isDrawing: () => sceneRef?.annotations?.isDrawing() ?? false
   };
 

--- a/packages/ui/src/lib/components/Stage/components/Stage/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/Stage/types.ts
@@ -85,6 +85,8 @@ export type StageProps = {
 export interface StageExports {
   annotations: {
     clear: (layerId: string) => void;
+    toRLE: () => Promise<Uint8Array>;
+    fromRLE: (rleData: Uint8Array, width: number, height: number) => Promise<void>;
     isDrawing: () => boolean;
   };
 
@@ -92,6 +94,8 @@ export interface StageExports {
     clear: () => void;
     reset: () => void;
     toPng: () => Promise<Blob>;
+    toRLE: () => Promise<Uint8Array>;
+    fromRLE: (rleData: Uint8Array, width: number, height: number) => Promise<void>;
     isDrawing: () => boolean;
   };
   map: {

--- a/packages/ui/src/lib/components/Stage/components/Stage/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/Stage/types.ts
@@ -87,6 +87,7 @@ export interface StageExports {
     clear: (layerId: string) => void;
     toRLE: () => Promise<Uint8Array>;
     fromRLE: (rleData: Uint8Array, width: number, height: number) => Promise<void>;
+    loadMask: (layerId: string, rleData: Uint8Array) => Promise<void>;
     isDrawing: () => boolean;
   };
 

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -1,1 +1,2 @@
 export * from './components';
+export * from './utils/rle';

--- a/packages/ui/src/lib/utils/rle.ts
+++ b/packages/ui/src/lib/utils/rle.ts
@@ -1,0 +1,217 @@
+/**
+ * Run-Length Encoding utilities for binary mask compression
+ * Optimized for fog and annotation layers
+ */
+
+/**
+ * Encodes a binary mask using Run-Length Encoding
+ * @param data - Binary mask data (Uint8Array where each byte is 0 or 255)
+ * @returns Encoded RLE data as Uint8Array
+ */
+export function encodeRLE(data: Uint8Array): Uint8Array {
+  if (data.length === 0) return new Uint8Array(0);
+
+  const runs: number[] = [];
+  let currentValue = data[0];
+  let runLength = 1;
+
+  // First byte indicates the starting value (0 or 1)
+  runs.push(currentValue === 0 ? 0 : 1);
+
+  for (let i = 1; i < data.length; i++) {
+    if (data[i] === currentValue) {
+      runLength++;
+    } else {
+      // Store the run length
+      pushVarint(runs, runLength);
+      currentValue = data[i];
+      runLength = 1;
+    }
+  }
+
+  // Don't forget the last run
+  pushVarint(runs, runLength);
+
+  return new Uint8Array(runs);
+}
+
+/**
+ * Decodes RLE data back to binary mask
+ * @param encoded - RLE encoded data
+ * @param targetLength - Expected length of decoded data
+ * @returns Decoded binary mask as Uint8Array
+ */
+export function decodeRLE(encoded: Uint8Array, targetLength: number): Uint8Array {
+  if (encoded.length === 0) return new Uint8Array(targetLength);
+
+  const result = new Uint8Array(targetLength);
+  let position = 0;
+  let index = 0;
+
+  // First byte indicates the starting value
+  const startValue = encoded[index++];
+  let currentValue = startValue === 0 ? 0 : 255;
+
+  while (index < encoded.length && position < targetLength) {
+    const [runLength, newIndex] = readVarint(encoded, index);
+    index = newIndex;
+
+    // Fill the result array with the current value
+    const end = Math.min(position + runLength, targetLength);
+    for (let i = position; i < end; i++) {
+      result[i] = currentValue;
+    }
+
+    position = end;
+    // Toggle the current value
+    currentValue = currentValue === 0 ? 255 : 0;
+  }
+
+  return result;
+}
+
+/**
+ * Variable-length integer encoding (for efficient storage of run lengths)
+ * Uses continuation bit in MSB
+ */
+function pushVarint(array: number[], value: number): void {
+  while (value > 127) {
+    array.push((value & 0x7f) | 0x80);
+    value >>>= 7;
+  }
+  array.push(value & 0x7f);
+}
+
+/**
+ * Read a variable-length integer from the array
+ */
+function readVarint(array: Uint8Array, index: number): [number, number] {
+  let value = 0;
+  let shift = 0;
+
+  while (index < array.length) {
+    const byte = array[index++];
+    value |= (byte & 0x7f) << shift;
+    if ((byte & 0x80) === 0) {
+      break;
+    }
+    shift += 7;
+  }
+
+  return [value, index];
+}
+
+/**
+ * Converts a PNG blob to RLE encoded data
+ * @param blob - PNG image blob
+ * @param width - Image width
+ * @param height - Image height
+ * @returns RLE encoded data
+ */
+export async function pngToRLE(blob: Blob, width: number, height: number): Promise<Uint8Array> {
+  // Create an off-screen canvas
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+
+  if (!ctx) {
+    throw new Error('Failed to get canvas context');
+  }
+
+  // Load the image
+  const img = new Image();
+  const url = URL.createObjectURL(blob);
+
+  try {
+    await new Promise((resolve, reject) => {
+      img.onload = resolve;
+      img.onerror = reject;
+      img.src = url;
+    });
+
+    // Draw image to canvas
+    ctx.drawImage(img, 0, 0, width, height);
+
+    // Get image data
+    const imageData = ctx.getImageData(0, 0, width, height);
+    const pixels = imageData.data;
+
+    // Convert RGBA to binary (using alpha channel)
+    const binaryData = new Uint8Array(width * height);
+    for (let i = 0; i < binaryData.length; i++) {
+      // Use alpha channel (every 4th byte starting at index 3)
+      binaryData[i] = pixels[i * 4 + 3] > 127 ? 255 : 0;
+    }
+
+    // Encode to RLE
+    return encodeRLE(binaryData);
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
+/**
+ * Converts RLE encoded data to a PNG blob
+ * @param rleData - RLE encoded data
+ * @param width - Image width
+ * @param height - Image height
+ * @returns PNG image blob
+ */
+export async function rleToPng(rleData: Uint8Array, width: number, height: number): Promise<Blob> {
+  // Decode RLE to binary
+  const binaryData = decodeRLE(rleData, width * height);
+
+  // Create canvas
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+
+  if (!ctx) {
+    throw new Error('Failed to get canvas context');
+  }
+
+  // Create image data
+  const imageData = ctx.createImageData(width, height);
+  const pixels = imageData.data;
+
+  // Convert binary to RGBA
+  for (let i = 0; i < binaryData.length; i++) {
+    const idx = i * 4;
+    const value = binaryData[i];
+    pixels[idx] = 0; // R
+    pixels[idx + 1] = 0; // G
+    pixels[idx + 2] = 0; // B
+    pixels[idx + 3] = value; // A (0 or 255)
+  }
+
+  // Put image data to canvas
+  ctx.putImageData(imageData, 0, 0);
+
+  // Convert to blob
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) {
+        resolve(blob);
+      } else {
+        reject(new Error('Failed to convert canvas to blob'));
+      }
+    }, 'image/png');
+  });
+}
+
+/**
+ * Gets the size of RLE data when encoded
+ */
+export function getRLESize(data: Uint8Array): number {
+  return encodeRLE(data).length;
+}
+
+/**
+ * Estimates compression ratio for RLE encoding
+ */
+export function estimateCompressionRatio(data: Uint8Array): number {
+  const encoded = encodeRLE(data);
+  return data.length / encoded.length;
+}


### PR DESCRIPTION
In an attempt to speed up the fog and annotation layer, this PR shifts the data saved from uploaded PNG masks, to Run Level Encoded (RLE) data. This means they are saved in the DB directly with a much smaller footprint. Because these text columns are still largish (though much smaller than image blobs) we now use YJS triggers based on timestamps to tell a connected playfield or editor to refresh these "images" and fetch new copies.

This is backwards compatible with the old system. The old PNGs can still be read, but they will migrate over as new fog or annotations are written.