### PR TITLE
Adjust cursor layer order. Use SVG instead of geometry

### DIFF
--- a/apps/web/src/lib/changelog/2025-09.md
+++ b/apps/web/src/lib/changelog/2025-09.md
@@ -25,3 +25,4 @@ Table Slayer now supports the ability to use movie files (MP4, webm) or GIF file
 
 - The popover in the Text Editor now positions correctly on mobile devices. [#335](https://github.com/Siege-Perilous/tableslayer/pull/335)
 - The cursor system now renders directly in the play field, rather than being calculated with complicated math, significantly improving performance. [#336](https://github.com/Siege-Perilous/tableslayer/pull/336)
+- Fog and drawing masks are now saved as [RLE](https://en.wikipedia.org/wiki/Run-length_encoding) encoding rather than PNGs. This vastly improves drawing performance. [#339](https://github.com/Siege-Perilous/tableslayer/pull/339)

--- a/packages/ui/src/lib/components/Stage/components/CursorLayer/CursorLayer.svelte
+++ b/packages/ui/src/lib/components/Stage/components/CursorLayer/CursorLayer.svelte
@@ -2,7 +2,7 @@
   import * as THREE from 'three';
   import { T, useTask } from '@threlte/core';
   import type { CursorData, CursorLayerProps } from './types';
-  import { SceneLayer } from '../Scene/types';
+  import { SceneLayer, SceneLayerOrder } from '../Scene/types';
 
   interface Props {
     props: CursorLayerProps;
@@ -70,7 +70,7 @@
       position={[cursor.worldPosition.x, cursor.worldPosition.y, cursor.worldPosition.z + 0.1]}
       layers={[SceneLayer.Overlay]}
     >
-      <T.Mesh geometry={shadowGeometry} position={[0, 0, -0.01]}>
+      <T.Mesh geometry={shadowGeometry} position={[0, 0, -0.01]} renderOrder={SceneLayerOrder.Cursor}>
         <T.MeshBasicMaterial
           color="#000000"
           transparent={true}
@@ -81,11 +81,11 @@
         />
       </T.Mesh>
 
-      <T.Mesh geometry={cursorOutlineGeometry}>
+      <T.Mesh geometry={cursorOutlineGeometry} renderOrder={SceneLayerOrder.Cursor}>
         <T.MeshBasicMaterial color="#ffffff" transparent={true} {opacity} depthTest={false} depthWrite={false} />
       </T.Mesh>
 
-      <T.Mesh geometry={cursorGeometry}>
+      <T.Mesh geometry={cursorGeometry} renderOrder={SceneLayerOrder.Cursor}>
         <T.MeshBasicMaterial
           color={cursor.color}
           transparent={true}

--- a/packages/ui/src/lib/components/Stage/components/CursorLayer/cursor.svg
+++ b/packages/ui/src/lib/components/Stage/components/CursorLayer/cursor.svg
@@ -1,0 +1,26 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <!-- Drop shadow -->
+  <defs>
+    <filter id="shadow" x="-50%" y="-50%" width="200%" height="200%">
+      <feGaussianBlur in="SourceAlpha" stdDeviation="2"/>
+      <feOffset dx="0" dy="1" result="offsetblur"/>
+      <feFlood flood-color="#000000" flood-opacity="0.2"/>
+      <feComposite in2="offsetblur" operator="in"/>
+      <feMerge>
+        <feMergeNode/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+  
+  <!-- Main circle with white stroke -->
+  <circle 
+    cx="32" 
+    cy="32" 
+    r="20" 
+    fill="currentColor" 
+    stroke="white" 
+    stroke-width="4"
+    filter="url(#shadow)"
+  />
+</svg>

--- a/packages/ui/src/lib/components/Stage/components/Scene/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/Scene/types.ts
@@ -30,7 +30,8 @@ export enum SceneLayerOrder {
   Grid = 50,
   EdgeOverlay = 70,
   Annotation = 80,
-  Measurement = 90
+  Measurement = 90,
+  Cursor = 100
 }
 
 export interface SceneLayerProps {


### PR DESCRIPTION
Changes the cursor in the playfield / Stage to use an SVG which removes the aliasing seen from the geometry system used before. Also makes sure that the cursor sits above the fog layer and isn't effected by post processing.