### PR TITLE
Allow markers to have tooltips which can show 

### DIFF
--- a/apps/docs/src/routes/(components)/stage/+page.svelte
+++ b/apps/docs/src/routes/(components)/stage/+page.svelte
@@ -151,8 +151,8 @@
     }
   }
 
-  function onMarkerSelected(marker: Marker) {
-    selectedMarker = marker;
+  function onMarkerSelected(marker: Marker | null) {
+    selectedMarker = marker ?? undefined;
   }
 
   function onMarkerContextMenu(marker: Marker, event: MouseEvent | TouchEvent) {

--- a/apps/web/src/lib/components/GameSession/AnnotationManager.svelte
+++ b/apps/web/src/lib/components/GameSession/AnnotationManager.svelte
@@ -285,6 +285,7 @@
     height: 100%;
     display: flex;
     flex-direction: column;
+    container-type: inline-size;
   }
 
   .annotationManager__content {
@@ -382,6 +383,17 @@
     width: 100%;
     background-color: var(--bgColorBlur);
     backdrop-filter: blur(10px);
+  }
+
+  @container (max-width: 360px) {
+    .annotationManager__header {
+      grid-template-columns: 1fr;
+      gap: 1rem;
+    }
+
+    .annotationManager__header > :global(button:first-child) {
+      width: 100%;
+    }
   }
   .annotationManager__lineWidthControl {
     display: flex;

--- a/apps/web/src/lib/components/GameSession/MarkerManager.svelte
+++ b/apps/web/src/lib/components/GameSession/MarkerManager.svelte
@@ -34,6 +34,7 @@
     IconEyeOff,
     IconX,
     IconPokerChip,
+    IconHandFinger,
     IconLocationPin
   } from '@tabler/icons-svelte';
   import { useUploadFileMutation, useDeleteMarkerMutation } from '$lib/queries';
@@ -47,7 +48,9 @@
     handleSelectActiveControl,
     socketUpdate,
     updateMarkerAndSave,
-    onMarkerDeleted
+    onMarkerDeleted,
+    pinnedMarkerIds = [],
+    onPinToggle
   }: {
     stageProps: StageProps;
     selectedMarkerId: string | undefined;
@@ -57,6 +60,8 @@
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     updateMarkerAndSave: (markerId: string, updateFn: (marker: any) => void) => void;
     onMarkerDeleted?: (markerId: string) => void;
+    pinnedMarkerIds?: string[];
+    onPinToggle?: (markerId: string, pinned: boolean) => void;
   } = $props();
 
   const uploadFile = useUploadFileMutation();
@@ -226,15 +231,41 @@
                   {/snippet}
                 </FormControl>
 
-                <FormControl label="Visible to" name="visibility">
+                <div class="markerManager__colorPicker">
+                  <FormControl label="Background color" name="shapeColor">
+                    {#snippet start()}
+                      <Popover>
+                        {#snippet trigger()}
+                          <ColorPickerSwatch color={marker.shapeColor} />
+                        {/snippet}
+                        {#snippet content()}
+                          <ColorPicker
+                            showOpacity={false}
+                            hex={marker.shapeColor}
+                            onUpdate={(colorData) =>
+                              updateMarkerAndSave(marker.id, (m) => (m.shapeColor = colorData.hex))}
+                          />
+                        {/snippet}
+                      </Popover>
+                    {/snippet}
+                    {#snippet input(inputProps)}
+                      <Input
+                        {...inputProps}
+                        value={marker.shapeColor}
+                        oninput={(e) => updateMarkerAndSave(marker.id, (m) => (m.shapeColor = e.currentTarget.value))}
+                      />
+                    {/snippet}
+                  </FormControl>
+                </div>
+                <FormControl label="Visibility" name="visibility">
                   {#snippet input(inputProps)}
                     <RadioButton
                       {...inputProps}
                       selected={marker.visibility.toString()}
                       options={[
-                        { label: 'DM only', value: MarkerVisibility.DM.toString() },
+                        { label: 'DM', value: MarkerVisibility.DM.toString() },
                         { label: 'Everyone', value: MarkerVisibility.Always.toString() },
-                        { label: 'Hover reveal', value: MarkerVisibility.Hover.toString() }
+                        { label: 'On hover', value: MarkerVisibility.Hover.toString() }
                       ]}
                       onSelectedChange={(value) => {
                         updateMarkerAndSave(marker.id, (m) => (m.visibility = Number(value)));
@@ -243,6 +274,23 @@
                     />
                   {/snippet}
                 </FormControl>
+                {#if marker.visibility !== MarkerVisibility.DM && onPinToggle}
+                  <FormControl label="Pin tooltip for players?" name="pin">
+                    {#snippet input(inputProps)}
+                      <RadioButton
+                        {...inputProps}
+                        selected={pinnedMarkerIds.includes(marker.id) ? 'pinned' : 'unpinned'}
+                        options={[
+                          { label: 'Yes', value: 'pinned' },
+                          { label: 'No', value: 'unpinned' }
+                        ]}
+                        onSelectedChange={(value) => {
+                          onPinToggle(marker.id, value === 'pinned');
+                        }}
+                      />
+                    {/snippet}
+                  </FormControl>
+                {/if}
                 <FormControl label="Label" name="label">
                   {#snippet input(inputProps)}
                     <Input
@@ -265,33 +313,7 @@
                 </FormControl>
               </div>
               <Spacer />
-              <div class="markerManager__colorPicker">
-                <FormControl label="Background color" name="shapeColor">
-                  {#snippet start()}
-                    <Popover>
-                      {#snippet trigger()}
-                        <ColorPickerSwatch color={marker.shapeColor} />
-                      {/snippet}
-                      {#snippet content()}
-                        <ColorPicker
-                          showOpacity={false}
-                          hex={marker.shapeColor}
-                          onUpdate={(colorData) =>
-                            updateMarkerAndSave(marker.id, (m) => (m.shapeColor = colorData.hex))}
-                        />
-                      {/snippet}
-                    </Popover>
-                  {/snippet}
-                  {#snippet input(inputProps)}
-                    <Input
-                      {...inputProps}
-                      value={marker.shapeColor}
-                      oninput={(e) => updateMarkerAndSave(marker.id, (m) => (m.shapeColor = e.currentTarget.value))}
-                    />
-                  {/snippet}
-                </FormControl>
-              </div>
-              <Spacer />
+
               <div class="markerManager__formGrid">
                 <FormControl label="Shape" name="shape">
                   {#snippet input(inputProps)}
@@ -394,14 +416,10 @@
                   Icon={marker.visibility === MarkerVisibility.Always
                     ? IconEye
                     : marker.visibility === MarkerVisibility.Hover
-                      ? IconLocationPin
+                      ? IconHandFinger
                       : IconEyeOff}
                   size="1.25rem"
-                  color={marker.visibility === MarkerVisibility.Always
-                    ? 'var(--fg)'
-                    : marker.visibility === MarkerVisibility.Hover
-                      ? 'var(--fgPrimary)'
-                      : 'var(--fgMuted)'}
+                  color={marker.visibility === MarkerVisibility.Always ? 'var(--fg)' : 'var(--fgMuted)'}
                 />
               </IconButton>
               {@render imagePreview(marker)}
@@ -468,6 +486,7 @@
     height: 100%;
     display: flex;
     flex-direction: column;
+    container-type: inline-size;
   }
 
   .markerManager__content {
@@ -505,6 +524,12 @@
     display: grid;
     grid-template-columns: 1fr 1fr;
     gap: 1rem;
+  }
+
+  @container (max-width: 420px) {
+    .markerManager__formGrid {
+      grid-template-columns: 1fr;
+    }
   }
   .markerManager__header {
     display: flex;

--- a/apps/web/src/lib/components/GameSession/MarkerManager.svelte
+++ b/apps/web/src/lib/components/GameSession/MarkerManager.svelte
@@ -232,8 +232,9 @@
                       {...inputProps}
                       selected={marker.visibility.toString()}
                       options={[
-                        { label: 'DM', value: MarkerVisibility.DM.toString() },
-                        { label: 'Everyone', value: MarkerVisibility.Always.toString() }
+                        { label: 'DM only', value: MarkerVisibility.DM.toString() },
+                        { label: 'Everyone', value: MarkerVisibility.Always.toString() },
+                        { label: 'Hover reveal', value: MarkerVisibility.Hover.toString() }
                       ]}
                       onSelectedChange={(value) => {
                         updateMarkerAndSave(marker.id, (m) => (m.visibility = Number(value)));
@@ -372,7 +373,10 @@
                 variant="ghost"
                 onclick={() => {
                   updateMarkerAndSave(marker.id, (m) => {
+                    // Cycle through: Always -> Hover -> DM -> Always
                     if (m.visibility === MarkerVisibility.Always) {
+                      m.visibility = MarkerVisibility.Hover;
+                    } else if (m.visibility === MarkerVisibility.Hover) {
                       m.visibility = MarkerVisibility.DM;
                     } else {
                       m.visibility = MarkerVisibility.Always;
@@ -380,11 +384,24 @@
                   });
                   socketUpdate();
                 }}
+                title={marker.visibility === MarkerVisibility.Always
+                  ? 'Visible to everyone'
+                  : marker.visibility === MarkerVisibility.Hover
+                    ? 'Hover reveal'
+                    : 'DM only'}
               >
                 <Icon
-                  Icon={marker.visibility === MarkerVisibility.Always ? IconEye : IconEyeOff}
+                  Icon={marker.visibility === MarkerVisibility.Always
+                    ? IconEye
+                    : marker.visibility === MarkerVisibility.Hover
+                      ? IconLocationPin
+                      : IconEyeOff}
                   size="1.25rem"
-                  color={marker.visibility === MarkerVisibility.Always ? 'var(--fg)' : 'var(--fgMuted)'}
+                  color={marker.visibility === MarkerVisibility.Always
+                    ? 'var(--fg)'
+                    : marker.visibility === MarkerVisibility.Hover
+                      ? 'var(--fgPrimary)'
+                      : 'var(--fgMuted)'}
                 />
               </IconButton>
               {@render imagePreview(marker)}

--- a/apps/web/src/lib/db/app/migrations/0034_marker-hover.sql
+++ b/apps/web/src/lib/db/app/migrations/0034_marker-hover.sql
@@ -1,0 +1,26 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_marker` (
+	`id` text PRIMARY KEY NOT NULL,
+	`scene_id` text NOT NULL,
+	`visibility` integer DEFAULT 1 NOT NULL,
+	`title` text DEFAULT 'New token' NOT NULL,
+	`label` text,
+	`image_location` text,
+	`image_scale` real DEFAULT 1 NOT NULL,
+	`position_x` real DEFAULT 0 NOT NULL,
+	`position_y` real DEFAULT 0 NOT NULL,
+	`shape` integer DEFAULT 1 NOT NULL,
+	`shape_color` text DEFAULT '#ffffff' NOT NULL,
+	`size` integer DEFAULT 1 NOT NULL,
+	`note` text,
+	FOREIGN KEY (`scene_id`) REFERENCES `scene`(`id`) ON UPDATE no action ON DELETE cascade,
+	CONSTRAINT "protected_marker_visibility" CHECK("__new_marker"."visibility" >= 0 AND "__new_marker"."visibility" <= 3),
+	CONSTRAINT "protected_marker_shape" CHECK("__new_marker"."shape" >= 0 AND "__new_marker"."shape" <= 3),
+	CONSTRAINT "protected_marker_size" CHECK("__new_marker"."size" >= 1 AND "__new_marker"."size" <= 3)
+);
+--> statement-breakpoint
+INSERT INTO `__new_marker`("id", "scene_id", "visibility", "title", "label", "image_location", "image_scale", "position_x", "position_y", "shape", "shape_color", "size", "note") SELECT "id", "scene_id", "visibility", "title", "label", "image_location", "image_scale", "position_x", "position_y", "shape", "shape_color", "size", "note" FROM `marker`;--> statement-breakpoint
+DROP TABLE `marker`;--> statement-breakpoint
+ALTER TABLE `__new_marker` RENAME TO `marker`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `idx_marker_scene_id` ON `marker` (`scene_id`);

--- a/apps/web/src/lib/db/app/migrations/meta/0034_snapshot.json
+++ b/apps/web/src/lib/db/app/migrations/meta/0034_snapshot.json
@@ -1,0 +1,1832 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0cb62ad9-6490-4135-bc27-fd792ca217c1",
+  "prevId": "f09b0f24-6f79-415e-bbdb-5efccaf47141",
+  "tables": {
+    "annotations": {
+      "name": "annotations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'New Annotation'"
+        },
+        "opacity": {
+          "name": "opacity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#FF0000'"
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mask": {
+          "name": "mask",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_annotations_scene_id": {
+          "name": "idx_annotations_scene_id",
+          "columns": ["scene_id"],
+          "isUnique": false
+        },
+        "idx_annotations_order": {
+          "name": "idx_annotations_order",
+          "columns": ["scene_id", "order"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "annotations_scene_id_scene_id_fk": {
+          "name": "annotations_scene_id_scene_id_fk",
+          "tableFrom": "annotations",
+          "tableTo": "scene",
+          "columnsFrom": ["scene_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "protected_annotation_opacity": {
+          "name": "protected_annotation_opacity",
+          "value": "\"annotations\".\"opacity\" >= 0 AND \"annotations\".\"opacity\" <= 1"
+        },
+        "protected_annotation_visibility": {
+          "name": "protected_annotation_visibility",
+          "value": "\"annotations\".\"visibility\" >= 0 AND \"annotations\".\"visibility\" <= 1"
+        }
+      }
+    },
+    "email_verification_codes": {
+      "name": "email_verification_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') + 60 * 15)"
+        }
+      },
+      "indexes": {
+        "email_verification_codes_user_id_unique": {
+          "name": "email_verification_codes_user_id_unique",
+          "columns": ["user_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "email_verification_codes_user_id_users_id_fk": {
+          "name": "email_verification_codes_user_id_users_id_fk",
+          "tableFrom": "email_verification_codes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "files": {
+      "name": "files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "files_location_unique": {
+          "name": "files_location_unique",
+          "columns": ["location"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "game_session": {
+      "name": "game_session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "party_id": {
+          "name": "party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "unique_party_name": {
+          "name": "unique_party_name",
+          "columns": ["party_id", "slug"],
+          "isUnique": true
+        },
+        "idx_game_session_party_id": {
+          "name": "idx_game_session_party_id",
+          "columns": ["party_id"],
+          "isUnique": false
+        },
+        "idx_game_session_last_updated": {
+          "name": "idx_game_session_last_updated",
+          "columns": ["last_updated"],
+          "isUnique": false
+        },
+        "idx_game_session_slug": {
+          "name": "idx_game_session_slug",
+          "columns": ["slug"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "game_session_party_id_party_id_fk": {
+          "name": "game_session_party_id_party_id_fk",
+          "tableFrom": "game_session",
+          "tableTo": "party",
+          "columnsFrom": ["party_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "marker": {
+      "name": "marker",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scene_id": {
+          "name": "scene_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'New token'"
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_location": {
+          "name": "image_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "image_scale": {
+          "name": "image_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "position_x": {
+          "name": "position_x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "position_y": {
+          "name": "position_y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "shape": {
+          "name": "shape",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "shape_color": {
+          "name": "shape_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#ffffff'"
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_marker_scene_id": {
+          "name": "idx_marker_scene_id",
+          "columns": ["scene_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "marker_scene_id_scene_id_fk": {
+          "name": "marker_scene_id_scene_id_fk",
+          "tableFrom": "marker",
+          "tableTo": "scene",
+          "columnsFrom": ["scene_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "protected_marker_visibility": {
+          "name": "protected_marker_visibility",
+          "value": "\"marker\".\"visibility\" >= 0 AND \"marker\".\"visibility\" <= 3"
+        },
+        "protected_marker_shape": {
+          "name": "protected_marker_shape",
+          "value": "\"marker\".\"shape\" >= 0 AND \"marker\".\"shape\" <= 3"
+        },
+        "protected_marker_size": {
+          "name": "protected_marker_size",
+          "value": "\"marker\".\"size\" >= 1 AND \"marker\".\"size\" <= 3"
+        }
+      }
+    },
+    "party_invite": {
+      "name": "party_invite",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "party_id": {
+          "name": "party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "party_invite_code_unique": {
+          "name": "party_invite_code_unique",
+          "columns": ["code"],
+          "isUnique": true
+        },
+        "idx_party_invite_party_id": {
+          "name": "idx_party_invite_party_id",
+          "columns": ["party_id"],
+          "isUnique": false
+        },
+        "idx_party_invite_email": {
+          "name": "idx_party_invite_email",
+          "columns": ["email"],
+          "isUnique": false
+        },
+        "idx_party_invite_code": {
+          "name": "idx_party_invite_code",
+          "columns": ["code"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "party_invite_party_id_party_id_fk": {
+          "name": "party_invite_party_id_party_id_fk",
+          "tableFrom": "party_invite",
+          "tableTo": "party",
+          "columnsFrom": ["party_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "party_invite_invited_by_users_id_fk": {
+          "name": "party_invite_invited_by_users_id_fk",
+          "tableFrom": "party_invite",
+          "tableTo": "users",
+          "columnsFrom": ["invited_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "party_member": {
+      "name": "party_member",
+      "columns": {
+        "party_id": {
+          "name": "party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_party_member_party_id": {
+          "name": "idx_party_member_party_id",
+          "columns": ["party_id"],
+          "isUnique": false
+        },
+        "idx_party_member_user_id": {
+          "name": "idx_party_member_user_id",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "idx_party_member_party_role": {
+          "name": "idx_party_member_party_role",
+          "columns": ["party_id", "role"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "party_member_party_id_party_id_fk": {
+          "name": "party_member_party_id_party_id_fk",
+          "tableFrom": "party_member",
+          "tableTo": "party",
+          "columnsFrom": ["party_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "party_member_user_id_users_id_fk": {
+          "name": "party_member_user_id_users_id_fk",
+          "tableFrom": "party_member",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "id": {
+          "columns": ["party_id", "user_id"],
+          "name": "id"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "party": {
+      "name": "party",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_file_id": {
+          "name": "avatar_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "pause_screen_file_id": {
+          "name": "pause_screen_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "active_scene_id": {
+          "name": "active_scene_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_paused": {
+          "name": "is_paused",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "tv_size": {
+          "name": "tv_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 40
+        },
+        "default_grid_type": {
+          "name": "default_grid_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "default_display_size_x": {
+          "name": "default_display_size_x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 17.77
+        },
+        "default_display_size_y": {
+          "name": "default_display_size_y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "default_resolution_x": {
+          "name": "default_resolution_x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1920
+        },
+        "default_resolution_y": {
+          "name": "default_resolution_y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1080
+        },
+        "default_display_padding_x": {
+          "name": "default_display_padding_x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 16
+        },
+        "default_display_padding_y": {
+          "name": "default_display_padding_y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 16
+        },
+        "default_grid_spacing": {
+          "name": "default_grid_spacing",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "default_line_thickness": {
+          "name": "default_line_thickness",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "plan_next_billing_date": {
+          "name": "plan_next_billing_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plan_expiration_date": {
+          "name": "plan_expiration_date",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plan_status": {
+          "name": "plan_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lemon_squeezy_customer_id": {
+          "name": "lemon_squeezy_customer_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "plan": {
+          "name": "plan",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'free'"
+        }
+      },
+      "indexes": {
+        "party_name_unique": {
+          "name": "party_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "party_slug_unique": {
+          "name": "party_slug_unique",
+          "columns": ["slug"],
+          "isUnique": true
+        },
+        "idx_party_slug": {
+          "name": "idx_party_slug",
+          "columns": ["slug"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "party_avatar_file_id_files_id_fk": {
+          "name": "party_avatar_file_id_files_id_fk",
+          "tableFrom": "party",
+          "tableTo": "files",
+          "columnsFrom": ["avatar_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "party_pause_screen_file_id_files_id_fk": {
+          "name": "party_pause_screen_file_id_files_id_fk",
+          "tableFrom": "party",
+          "tableTo": "files",
+          "columnsFrom": ["pause_screen_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "protected_slug_check": {
+          "name": "protected_slug_check",
+          "value": "slug NOT IN ('signup', 'login', 'forgot-password', 'reset-password', 'verify-email', 'accept-invite', 'api', 'invalidate-invite', 'logout', 'create-party', 'profile', 'test', 'api', 'healthcheck', 'help', 'tos', 'promo')"
+        }
+      }
+    },
+    "promo_redemptions": {
+      "name": "promo_redemptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "promo_id": {
+          "name": "promo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "party_id": {
+          "name": "party_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "redeemed_at": {
+          "name": "redeemed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "unique_promo_user": {
+          "name": "unique_promo_user",
+          "columns": ["promo_id", "user_id"],
+          "isUnique": true
+        },
+        "idx_promo_redemptions_promo_id": {
+          "name": "idx_promo_redemptions_promo_id",
+          "columns": ["promo_id"],
+          "isUnique": false
+        },
+        "idx_promo_redemptions_user_id": {
+          "name": "idx_promo_redemptions_user_id",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "idx_promo_redemptions_party_id": {
+          "name": "idx_promo_redemptions_party_id",
+          "columns": ["party_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "promo_redemptions_promo_id_promos_id_fk": {
+          "name": "promo_redemptions_promo_id_promos_id_fk",
+          "tableFrom": "promo_redemptions",
+          "tableTo": "promos",
+          "columnsFrom": ["promo_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "promo_redemptions_user_id_users_id_fk": {
+          "name": "promo_redemptions_user_id_users_id_fk",
+          "tableFrom": "promo_redemptions",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "promo_redemptions_party_id_party_id_fk": {
+          "name": "promo_redemptions_party_id_party_id_fk",
+          "tableFrom": "promo_redemptions",
+          "tableTo": "party",
+          "columnsFrom": ["party_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "promos": {
+      "name": "promos",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "max_uses": {
+          "name": "max_uses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "promos_key_unique": {
+          "name": "promos_key_unique",
+          "columns": ["key"],
+          "isUnique": true
+        },
+        "idx_promos_key": {
+          "name": "idx_promos_key",
+          "columns": ["key"],
+          "isUnique": false
+        },
+        "idx_promos_created_by": {
+          "name": "idx_promos_created_by",
+          "columns": ["created_by"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "promos_created_by_users_id_fk": {
+          "name": "promos_created_by_users_id_fk",
+          "tableFrom": "promos",
+          "tableTo": "users",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "valid_max_uses": {
+          "name": "valid_max_uses",
+          "value": "\"promos\".\"max_uses\" >= 1"
+        }
+      }
+    },
+    "reset_password_codes": {
+      "name": "reset_password_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(strftime('%s', 'now') + 60 * 15)"
+        }
+      },
+      "indexes": {
+        "reset_password_codes_user_id_unique": {
+          "name": "reset_password_codes_user_id_unique",
+          "columns": ["user_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "reset_password_codes_user_id_users_id_fk": {
+          "name": "reset_password_codes_user_id_users_id_fk",
+          "tableFrom": "reset_password_codes",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scene": {
+      "name": "scene",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'New Scene'"
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "background_color": {
+          "name": "background_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#0b0b0c'"
+        },
+        "display_padding_x": {
+          "name": "display_padding_x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 16
+        },
+        "display_padding_y": {
+          "name": "display_padding_y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 16
+        },
+        "display_size_x": {
+          "name": "display_size_x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 17.77
+        },
+        "display_size_y": {
+          "name": "display_size_y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "display_resolution_x": {
+          "name": "display_resolution_x",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1920
+        },
+        "display_resolution_y": {
+          "name": "display_resolution_y",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1080
+        },
+        "fog_of_war_url": {
+          "name": "fog_of_war_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fog_of_war_mask": {
+          "name": "fog_of_war_mask",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fog_of_war_color": {
+          "name": "fog_of_war_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#000'"
+        },
+        "fog_of_war_opacity_dm": {
+          "name": "fog_of_war_opacity_dm",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.3
+        },
+        "fog_of_war_opacity_player": {
+          "name": "fog_of_war_opacity_player",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.9
+        },
+        "map_location": {
+          "name": "map_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "map_thumb_location": {
+          "name": "map_thumb_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "map_rotation": {
+          "name": "map_rotation",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "map_offset_x": {
+          "name": "map_offset_x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "map_offset_y": {
+          "name": "map_offset_y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "map_zoom": {
+          "name": "map_zoom",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "grid_type": {
+          "name": "grid_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "grid_spacing": {
+          "name": "grid_spacing",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "grid_opacity": {
+          "name": "grid_opacity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.8
+        },
+        "grid_line_color": {
+          "name": "grid_line_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#E6E6E6'"
+        },
+        "grid_line_thickness": {
+          "name": "grid_line_thickness",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "grid_shadow_color": {
+          "name": "grid_shadow_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#000000'"
+        },
+        "grid_shadow_spread": {
+          "name": "grid_shadow_spread",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "grid_shadow_blur": {
+          "name": "grid_shadow_blur",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "grid_shadow_opacity": {
+          "name": "grid_shadow_opacity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.4
+        },
+        "scene_offset_x": {
+          "name": "scene_offset_x",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "scene_offset_y": {
+          "name": "scene_offset_y",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "scene_rotation": {
+          "name": "scene_rotation",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "weather_fov": {
+          "name": "weather_fov",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 60
+        },
+        "weather_intensity": {
+          "name": "weather_intensity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "weather_opacity": {
+          "name": "weather_opacity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "weather_type": {
+          "name": "weather_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "fog_enabled": {
+          "name": "fog_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "fog_color": {
+          "name": "fog_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#a0a0a0'"
+        },
+        "fog_opacity": {
+          "name": "fog_opacity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.8
+        },
+        "edge_enabled": {
+          "name": "edge_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "edge_url": {
+          "name": "edge_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "edge_opacity": {
+          "name": "edge_opacity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.3
+        },
+        "edge_scale": {
+          "name": "edge_scale",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 2
+        },
+        "edge_fade_start": {
+          "name": "edge_fade_start",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.2
+        },
+        "edge_fade_end": {
+          "name": "edge_fade_end",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "effects_enabled": {
+          "name": "effects_enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "effects_bloom_intensity": {
+          "name": "effects_bloom_intensity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "effects_bloom_threshold": {
+          "name": "effects_bloom_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "effects_bloom_smoothing": {
+          "name": "effects_bloom_smoothing",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.3
+        },
+        "effects_bloom_radius": {
+          "name": "effects_bloom_radius",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.5
+        },
+        "effects_bloom_levels": {
+          "name": "effects_bloom_levels",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 10
+        },
+        "effects_bloom_mip_map_blur": {
+          "name": "effects_bloom_mip_map_blur",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "effects_chromatic_aberration_intensity": {
+          "name": "effects_chromatic_aberration_intensity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "effects_lut_url": {
+          "name": "effects_lut_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effects_tone_mapping_mode": {
+          "name": "effects_tone_mapping_mode",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "marker_stroke_color": {
+          "name": "marker_stroke_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#000000'"
+        },
+        "marker_stroke_width": {
+          "name": "marker_stroke_width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 50
+        },
+        "marker_text_color": {
+          "name": "marker_text_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#ffffff'"
+        },
+        "marker_text_stroke_color": {
+          "name": "marker_text_stroke_color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'#000000'"
+        },
+        "annotation_layers": {
+          "name": "annotation_layers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "unique_session_scene_order": {
+          "name": "unique_session_scene_order",
+          "columns": ["session_id", "order"],
+          "isUnique": true
+        },
+        "idx_scene_order": {
+          "name": "idx_scene_order",
+          "columns": ["order"],
+          "isUnique": false
+        },
+        "idx_scene_game_session_id": {
+          "name": "idx_scene_game_session_id",
+          "columns": ["session_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scene_session_id_game_session_id_fk": {
+          "name": "scene_session_id_game_session_id_fk",
+          "tableFrom": "scene",
+          "tableTo": "game_session",
+          "columnsFrom": ["session_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "protected_fog_of_war_opacity_dm": {
+          "name": "protected_fog_of_war_opacity_dm",
+          "value": "\"scene\".\"fog_of_war_opacity_dm\" >= 0 AND \"scene\".\"fog_of_war_opacity_dm\" <= 1"
+        },
+        "protected_fog_of_war_opacity_player": {
+          "name": "protected_fog_of_war_opacity_player",
+          "value": "\"scene\".\"fog_of_war_opacity_player\" >= 0 AND \"scene\".\"fog_of_war_opacity_player\" <= 1"
+        },
+        "protected_grid_opacity": {
+          "name": "protected_grid_opacity",
+          "value": "\"scene\".\"grid_opacity\" >= 0 AND \"scene\".\"grid_opacity\" <= 1"
+        },
+        "protected_weather_intensity": {
+          "name": "protected_weather_intensity",
+          "value": "\"scene\".\"weather_intensity\" >= 0 AND \"scene\".\"weather_intensity\" <= 1"
+        },
+        "protected_weather_opacity": {
+          "name": "protected_weather_opacity",
+          "value": "\"scene\".\"weather_opacity\" >= 0 AND \"scene\".\"weather_opacity\" <= 1"
+        },
+        "protected_fog_opacity": {
+          "name": "protected_fog_opacity",
+          "value": "\"scene\".\"fog_opacity\" >= 0 AND \"scene\".\"fog_opacity\" <= 1"
+        },
+        "protected_edge_opacity": {
+          "name": "protected_edge_opacity",
+          "value": "\"scene\".\"edge_opacity\" >= 0 AND \"scene\".\"edge_opacity\" <= 1"
+        },
+        "protected_edge_fade_start": {
+          "name": "protected_edge_fade_start",
+          "value": "\"scene\".\"edge_fade_start\" >= 0 AND \"scene\".\"edge_fade_start\" <= 1"
+        },
+        "protected_edge_fade_end": {
+          "name": "protected_edge_fade_end",
+          "value": "\"scene\".\"edge_fade_end\" >= 0 AND \"scene\".\"edge_fade_end\" <= 1"
+        }
+      }
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_session_user_id": {
+          "name": "idx_session_user_id",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_users_id_fk": {
+          "name": "session_user_id_users_id_fk",
+          "tableFrom": "session",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_files": {
+      "name": "user_files",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_id": {
+          "name": "file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_user_files_user_id": {
+          "name": "idx_user_files_user_id",
+          "columns": ["user_id"],
+          "isUnique": false
+        },
+        "idx_user_files_file_id": {
+          "name": "idx_user_files_file_id",
+          "columns": ["file_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "user_files_user_id_users_id_fk": {
+          "name": "user_files_user_id_users_id_fk",
+          "tableFrom": "user_files",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_files_file_id_files_id_fk": {
+          "name": "user_files_file_id_files_id_fk",
+          "tableFrom": "user_files",
+          "tableTo": "files",
+          "columnsFrom": ["file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "id": {
+          "columns": ["user_id", "file_id"],
+          "name": "id"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "google_id": {
+          "name": "google_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_file_id": {
+          "name": "avatar_file_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "favorite_party": {
+          "name": "favorite_party",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        },
+        "users_google_id_unique": {
+          "name": "users_google_id_unique",
+          "columns": ["google_id"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "users_avatar_file_id_files_id_fk": {
+          "name": "users_avatar_file_id_files_id_fk",
+          "tableFrom": "users",
+          "tableTo": "files",
+          "columnsFrom": ["avatar_file_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "users_favorite_party_party_id_fk": {
+          "name": "users_favorite_party_party_id_fk",
+          "tableFrom": "users",
+          "tableTo": "party",
+          "columnsFrom": ["favorite_party"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/web/src/lib/db/app/migrations/meta/_journal.json
+++ b/apps/web/src/lib/db/app/migrations/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1757908906480,
       "tag": "0033_rle-mask",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "6",
+      "when": 1757959059295,
+      "tag": "0034_marker-hover",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/src/lib/db/app/schema.ts
+++ b/apps/web/src/lib/db/app/schema.ts
@@ -447,7 +447,7 @@ export const markerTable = sqliteTable(
   },
   (table) => [
     index('idx_marker_scene_id').on(table.sceneId),
-    check('protected_marker_visibility', sql`${table.visibility} >= 0 AND ${table.visibility} <= 2`),
+    check('protected_marker_visibility', sql`${table.visibility} >= 0 AND ${table.visibility} <= 3`),
     check('protected_marker_shape', sql`${table.shape} >= 0 AND ${table.shape} <= 3`),
     check('protected_marker_size', sql`${table.size} >= 1 AND ${table.size} <= 3`)
   ]

--- a/apps/web/src/lib/utils/buildSceneProps.ts
+++ b/apps/web/src/lib/utils/buildSceneProps.ts
@@ -34,7 +34,7 @@ export const buildSceneProps = (
   let markers: Marker[] = [];
   if (activeSceneMarkers && Array.isArray(activeSceneMarkers)) {
     markers = activeSceneMarkers
-      // Filter out DM-only markers for client mode
+      // Filter out DM-only markers for client mode, but keep Hover markers (they can be revealed by DM)
       .filter((marker) => mode === 'editor' || marker.visibility !== 1) // 1 = MarkerVisibility.DM
       .map((marker) => ({
         id: marker.id,

--- a/apps/web/src/lib/utils/yjs/PartyDataManager.ts
+++ b/apps/web/src/lib/utils/yjs/PartyDataManager.ts
@@ -1,4 +1,4 @@
-import type { Marker, StageProps } from '@tableslayer/ui';
+import type { HoveredMarker, Marker, StageProps } from '@tableslayer/ui';
 import YPartyKitProvider from 'y-partykit/provider';
 import * as Y from 'yjs';
 import { devLog, devWarn } from '../debug';
@@ -294,6 +294,37 @@ export class PartyDataManager {
         });
       }
     }
+  }
+
+  /**
+   * Update hovered marker state (DM only)
+   * This broadcasts which marker the DM is hovering over to all players
+   */
+  updateHoveredMarker(marker: HoveredMarker | null) {
+    if (this.isConnected && this.gameSessionProvider.awareness) {
+      this.gameSessionProvider.awareness.setLocalStateField('hoveredMarker', marker);
+    }
+  }
+
+  /**
+   * Get current hovered marker from awareness (for players to see what DM is hovering)
+   */
+  getHoveredMarker(): HoveredMarker | null {
+    if (this.gameSessionProvider.awareness) {
+      const states = this.gameSessionProvider.awareness.getStates();
+
+      // Look for any DM's hovered marker (last one wins if multiple DMs)
+      let hoveredMarker: HoveredMarker | null = null;
+      states.forEach((state) => {
+        if (state.hoveredMarker) {
+          hoveredMarker = state.hoveredMarker as HoveredMarker;
+        }
+      });
+
+      return hoveredMarker;
+    }
+
+    return null;
   }
 
   /**

--- a/apps/web/src/lib/utils/yjs/PartyDataManager.ts
+++ b/apps/web/src/lib/utils/yjs/PartyDataManager.ts
@@ -350,6 +350,34 @@ export class PartyDataManager {
   }
 
   /**
+   * Update pinned markers (DM pins markers for player view)
+   * Uses awareness protocol for ephemeral state like cursors
+   */
+  updatePinnedMarkers(markerIds: string[]) {
+    if (this.isConnected && this.gameSessionProvider.awareness) {
+      this.gameSessionProvider.awareness.setLocalStateField('pinnedMarkers', markerIds);
+      devLog('yjs', `[${this.clientId}] Updated pinned markers:`, markerIds);
+    }
+  }
+
+  /**
+   * Get current pinned markers from DM
+   */
+  getPinnedMarkers(): string[] {
+    if (this.gameSessionProvider.awareness) {
+      // Look through all connected clients for pinned markers
+      // Only the DM should be broadcasting these
+      const states = this.gameSessionProvider.awareness.getStates();
+      for (const [, state] of states) {
+        if (state.pinnedMarkers && Array.isArray(state.pinnedMarkers)) {
+          return state.pinnedMarkers;
+        }
+      }
+    }
+    return [];
+  }
+
+  /**
    * Set up observers for Y.js data structures
    */
   private setupObservers() {

--- a/apps/web/src/lib/utils/yjs/stores.ts
+++ b/apps/web/src/lib/utils/yjs/stores.ts
@@ -83,6 +83,10 @@ export function usePartyData() {
     updateHoveredMarker: (marker: any) => partyDataManager!.updateHoveredMarker(marker),
     getHoveredMarker: () => partyDataManager!.getHoveredMarker(),
 
+    // Pinned markers management (DM pins markers for player view)
+    updatePinnedMarkers: (markerIds: string[]) => partyDataManager!.updatePinnedMarkers(markerIds),
+    getPinnedMarkers: () => partyDataManager!.getPinnedMarkers(),
+
     // Scenes list
     getScenesList: (): SceneMetadata[] => partyDataManager!.getScenesList(),
 

--- a/apps/web/src/lib/utils/yjs/stores.ts
+++ b/apps/web/src/lib/utils/yjs/stores.ts
@@ -79,6 +79,10 @@ export function usePartyData() {
     ) => partyDataManager!.updateMeasurement(startPoint, endPoint, type, measurementProps),
     getMeasurements: () => partyDataManager!.getMeasurements(),
 
+    // Hovered marker management (DM hover to reveal markers to players)
+    updateHoveredMarker: (marker: any) => partyDataManager!.updateHoveredMarker(marker),
+    getHoveredMarker: () => partyDataManager!.getHoveredMarker(),
+
     // Scenes list
     getScenesList: (): SceneMetadata[] => partyDataManager!.getScenesList(),
 

--- a/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
+++ b/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
@@ -1249,44 +1249,6 @@
 
   const onMarkerSelected = (marker: Marker | null) => {
     selectedMarkerId = marker?.id || undefined;
-
-    // Broadcast Hover visibility markers when selected
-    if (stageProps.mode === StageMode.DM) {
-      if (marker && marker.visibility === MarkerVisibility.Hover) {
-        const hoveredMarkerData = {
-          id: marker.id,
-          position: {
-            x: marker.position.x,
-            y: marker.position.y,
-            z: 0
-          },
-          tooltip: {
-            title: marker.title,
-            content: marker.note ? JSON.stringify(marker.note) : '',
-            imageUrl: marker.imageUrl || undefined
-          }
-        };
-
-        hoveredMarker = hoveredMarkerData;
-
-        if (partyData) {
-          partyData.updateHoveredMarker(hoveredMarkerData);
-          devLog('markers', 'Broadcasting selected hover marker:', hoveredMarkerData);
-        }
-      } else {
-        // Clear hover broadcast if no marker selected or selecting a non-Hover marker
-        hoveredMarker = null;
-        if (partyData) {
-          partyData.updateHoveredMarker(null);
-          devLog(
-            'markers',
-            marker
-              ? 'Clearing hover marker broadcast (non-hover marker selected)'
-              : 'Clearing hover marker broadcast (no selection)'
-          );
-        }
-      }
-    }
   };
 
   const onMarkerContextMenu = (marker: Marker, event: MouseEvent | TouchEvent) => {
@@ -1340,21 +1302,16 @@
           devLog('markers', 'Broadcasting hovered marker:', hoveredMarkerData);
         }
       } else {
-        // Only clear if the selected marker is not a Hover visibility marker
-        const selectedMarker = stageProps.marker.markers.find((m) => m.id === selectedMarkerId);
-        if (!selectedMarker || selectedMarker.visibility !== MarkerVisibility.Hover) {
-          // Clear both local and broadcast state
-          hoveredMarker = null;
-          if (partyData) {
-            partyData.updateHoveredMarker(null);
-          }
-          if (marker && marker.visibility !== MarkerVisibility.Hover) {
-            devLog('markers', 'Marker not set to Hover visibility, not broadcasting');
-          } else {
-            devLog('markers', 'Clearing hovered marker (no Hover marker selected)');
-          }
+        // Clear hover broadcast when not hovering a Hover visibility marker
+        hoveredMarker = null;
+        if (partyData) {
+          partyData.updateHoveredMarker(null);
         }
-        // If selected marker IS a Hover marker, keep the broadcast active
+        if (marker && marker.visibility !== MarkerVisibility.Hover) {
+          devLog('markers', 'Marker not set to Hover visibility, not broadcasting');
+        } else {
+          devLog('markers', 'Clearing hovered marker');
+        }
       }
     }
   };

--- a/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
+++ b/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
@@ -2710,6 +2710,8 @@
             {handleSelectActiveControl}
             {updateMarkerAndSave}
             {onMarkerDeleted}
+            {pinnedMarkerIds}
+            {onPinToggle}
           />
         {/key}
       {/if}

--- a/apps/web/src/routes/(app)/[party]/play/+page@.svelte
+++ b/apps/web/src/routes/(app)/[party]/play/+page@.svelte
@@ -33,6 +33,7 @@
   let latestMeasurement: MeasurementData | null = $state(null);
   let hoveredMarkerId: string | null = $state(null);
   let hoveredMarkerData: any = $state(null);
+  let pinnedMarkerIds: string[] = $state([]);
 
   // Convert cursors to format expected by CursorLayer
   let cursorArray = $derived(
@@ -436,6 +437,9 @@
           });
         }
 
+        // Update pinned markers from Y.js awareness
+        pinnedMarkerIds = partyData!.getPinnedMarkers();
+
         // Also get scene data if we have an active scene
         if (updatedPartyState.activeSceneId) {
           // If we don't have the game session ID, we need to find it
@@ -621,6 +625,9 @@
           });
         }
 
+        // Update pinned markers from Y.js awareness
+        pinnedMarkerIds = partyData!.getPinnedMarkers();
+
         // Also get scene data if we have an active scene
         if (updatedPartyState.activeSceneId) {
           devLog('playfield', 'Attempting to get scene data:', {
@@ -689,7 +696,7 @@
   function onMarkerHover() {} // Players can't control hover, only receive it
 
   const onMarkerSelected = (marker: Marker | null) => {
-    selectedMarker = marker;
+    selectedMarker = marker ?? undefined;
   };
 
   function onStageLoading() {
@@ -889,6 +896,7 @@
     bind:this={stage}
     props={stageProps}
     {hoveredMarkerId}
+    {pinnedMarkerIds}
     receivedMeasurement={latestMeasurement
       ? {
           startPoint: latestMeasurement.startPoint,

--- a/apps/web/src/routes/(app)/[party]/play/+page@.svelte
+++ b/apps/web/src/routes/(app)/[party]/play/+page@.svelte
@@ -31,6 +31,8 @@
   let cursors: Record<string, CursorData> = $state({});
   let measurements: Record<string, MeasurementData> = $state({});
   let latestMeasurement: MeasurementData | null = $state(null);
+  let hoveredMarkerId: string | null = $state(null);
+  let hoveredMarkerData: any = $state(null);
 
   // Convert cursors to format expected by CursorLayer
   let cursorArray = $derived(
@@ -65,7 +67,7 @@
   let stageElement: HTMLDivElement | undefined = $state();
   let stageProps: StageProps = $state({
     ...StageDefaultProps,
-    mode: 1,
+    mode: 1, // StageMode.Player = 1
     activeLayer: MapLayerType.None,
     scene: { ...StageDefaultProps.scene, autoFit: true, offset: { x: 0, y: 0 } }
   });
@@ -423,6 +425,17 @@
         }
         measurements = yjsMeasurements;
 
+        // Update hovered marker from Y.js awareness (for players to see what DM is hovering)
+        const hoveredMarker = partyData!.getHoveredMarker();
+        hoveredMarkerId = hoveredMarker?.id ?? null;
+        if (hoveredMarker) {
+          console.log('[Play Route] Received hovered marker from Y.js:', {
+            id: hoveredMarker.id,
+            hoveredMarkerId,
+            hasTooltip: hoveredMarker.tooltip
+          });
+        }
+
         // Also get scene data if we have an active scene
         if (updatedPartyState.activeSceneId) {
           // If we don't have the game session ID, we need to find it
@@ -597,6 +610,17 @@
         }
         measurements = yjsMeasurements;
 
+        // Update hovered marker from Y.js awareness (for players to see what DM is hovering)
+        const hoveredMarker = partyData!.getHoveredMarker();
+        hoveredMarkerId = hoveredMarker?.id ?? null;
+        if (hoveredMarker) {
+          console.log('[Play Route] Received hovered marker from Y.js:', {
+            id: hoveredMarker.id,
+            hoveredMarkerId,
+            hasTooltip: hoveredMarker.tooltip
+          });
+        }
+
         // Also get scene data if we have an active scene
         if (updatedPartyState.activeSceneId) {
           devLog('playfield', 'Attempting to get scene data:', {
@@ -662,8 +686,9 @@
   // Don't allow marker movement in player view
   function onMarkerMoved() {}
   function onMarkerAdded() {}
+  function onMarkerHover() {} // Players can't control hover, only receive it
 
-  const onMarkerSelected = (marker: Marker) => {
+  const onMarkerSelected = (marker: Marker | null) => {
     selectedMarker = marker;
   };
 
@@ -863,6 +888,7 @@
   <Stage
     bind:this={stage}
     props={stageProps}
+    {hoveredMarkerId}
     receivedMeasurement={latestMeasurement
       ? {
           startPoint: latestMeasurement.startPoint,
@@ -897,6 +923,7 @@
       onMarkerMoved,
       onMarkerSelected,
       onMarkerContextMenu,
+      onMarkerHover,
       // Measurements are read-only in playfield, but we still need the callbacks
       onMeasurementStart: () => {},
       onMeasurementUpdate: () => {},

--- a/packages/ui/src/lib/components/MarkerTooltip/MarkerTooltip.svelte
+++ b/packages/ui/src/lib/components/MarkerTooltip/MarkerTooltip.svelte
@@ -164,7 +164,7 @@
 
       cleanup = autoUpdate(virtualEl, tooltipElement!, async () => {
         const markerRadius = markerDiameter / 2;
-        const buffer = 10;
+        const buffer = 20; // Increased from 10 to 20 for more spacing
         const dynamicOffset = markerRadius + buffer;
 
         const { x, y } = await computePosition(virtualEl, tooltipElement!, {

--- a/packages/ui/src/lib/components/MarkerTooltip/MarkerTooltip.svelte
+++ b/packages/ui/src/lib/components/MarkerTooltip/MarkerTooltip.svelte
@@ -243,7 +243,7 @@
 
       cleanup = autoUpdate(virtualEl, tooltipElement!, async () => {
         const markerRadius = markerDiameter / 2;
-        const buffer = 20;
+        const buffer = 10;
         const arrowSize = 8;
         const dynamicOffset = markerRadius + buffer + arrowSize;
 

--- a/packages/ui/src/lib/components/MarkerTooltip/MarkerTooltip.svelte
+++ b/packages/ui/src/lib/components/MarkerTooltip/MarkerTooltip.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { Marker } from '../Stage/components/MarkerLayer/types';
+  import { type Marker, MarkerVisibility } from '../Stage/components/MarkerLayer/types';
   import { computePosition, flip, shift, offset, autoUpdate } from '@floating-ui/dom';
   import { Editor } from '../Editor';
   import { onMount, onDestroy } from 'svelte';
@@ -203,17 +203,17 @@
 {#if (markerContent || markerTitle) && position}
   <div
     bind:this={tooltipElement}
-    class="marker-tooltip"
+    class="markerTooltip"
     style="display: none;"
     role="tooltip"
     data-placement={currentPlacement}
     onmouseenter={handleTooltipMouseEnter}
     onmouseleave={handleTooltipMouseLeave}
   >
-    <div class="marker-tooltip__arrow" data-placement={currentPlacement}></div>
-    {#if isDM && onPinToggle && marker}
+    <div class="markerTooltip__arrow markerTooltip__arrow--{currentPlacement}"></div>
+    {#if isDM && onPinToggle && marker && marker.visibility !== MarkerVisibility.DM}
       <button
-        class="marker-tooltip__pin"
+        class="markerTooltip__pin"
         onclick={() => onPinToggle(marker.id, !isPinned)}
         title={isPinned ? 'Unpin from player view' : 'Pin to player view'}
       >
@@ -225,7 +225,7 @@
       </button>
     {/if}
     {#if markerTitle}
-      <div class="marker-tooltip__title">{markerTitle}</div>
+      <div class="markerTooltip__title {isDM ? 'markerTooltip__title--dm' : ''}">{markerTitle}</div>
     {/if}
     {#if markerContent}
       <Editor content={markerContent} editable={false} />
@@ -234,7 +234,7 @@
 {/if}
 
 <style>
-  .marker-tooltip {
+  .markerTooltip {
     max-width: 400px;
     background-color: var(--bg);
     padding: 1rem;
@@ -244,7 +244,7 @@
     position: relative;
   }
 
-  .marker-tooltip__pin {
+  .markerTooltip__pin {
     position: absolute;
     top: 0.5rem;
     right: 0.5rem;
@@ -262,25 +262,27 @@
       background 0.2s;
   }
 
-  .marker-tooltip__pin:hover {
+  .markerTooltip__pin:hover {
     color: var(--fgPrimary);
     background: var(--bgHover);
   }
 
-  .marker-tooltip__title {
+  .markerTooltip__title {
     font-weight: 600;
-    font-size: var(--text-md);
+    font-size: 1rem;
     margin-bottom: 0.5rem;
     color: var(--fg);
-    padding-right: 2rem; /* Make room for pin button */
+  }
+  .markerTooltip__title--dm {
+    padding-right: 2rem;
   }
 
-  .marker-tooltip__title:last-child {
+  .markerTooltip__title:last-child {
     margin-bottom: 0;
   }
 
   /* Arrow indicator */
-  .marker-tooltip__arrow {
+  .markerTooltip__arrow {
     position: absolute;
     width: 0;
     height: 0;
@@ -288,43 +290,36 @@
     pointer-events: none;
   }
 
-  /* Arrow when tooltip is above marker - simplified without pseudo-element */
-  .marker-tooltip__arrow[data-placement='top'] {
-    bottom: -7px;
+  /* Arrow modifiers for different placements */
+  .markerTooltip__arrow--top {
+    bottom: -8px;
     left: 50%;
     transform: translateX(-50%);
     border-width: 8px 8px 0 8px;
     border-color: var(--bg) transparent transparent transparent;
-    filter: drop-shadow(0 1px 0 var(--border));
   }
 
-  /* Arrow when tooltip is below marker - simplified */
-  .marker-tooltip__arrow[data-placement='bottom'] {
-    top: -7px;
+  .markerTooltip__arrow--bottom {
+    top: -8px;
     left: 50%;
     transform: translateX(-50%);
     border-width: 0 8px 8px 8px;
     border-color: transparent transparent var(--bg) transparent;
-    filter: drop-shadow(0 -1px 0 var(--border));
   }
 
-  /* Arrow when tooltip is to the left of marker - simplified */
-  .marker-tooltip__arrow[data-placement='left'] {
-    right: -7px;
+  .markerTooltip__arrow--left {
+    right: -8px;
     top: 50%;
     transform: translateY(-50%);
     border-width: 8px 0 8px 8px;
     border-color: transparent transparent transparent var(--bg);
-    filter: drop-shadow(1px 0 0 var(--border));
   }
 
-  /* Arrow when tooltip is to the right of marker - simplified */
-  .marker-tooltip__arrow[data-placement='right'] {
-    left: -7px;
+  .markerTooltip__arrow--right {
+    left: -8px;
     top: 50%;
     transform: translateY(-50%);
     border-width: 8px 8px 8px 0;
     border-color: transparent var(--bg) transparent transparent;
-    filter: drop-shadow(-1px 0 0 var(--border));
   }
 </style>

--- a/packages/ui/src/lib/components/MarkerTooltip/MarkerTooltip.svelte
+++ b/packages/ui/src/lib/components/MarkerTooltip/MarkerTooltip.svelte
@@ -9,13 +9,28 @@
     position: { x: number; y: number } | null;
     containerElement: HTMLElement | null;
     markerDiameter?: number;
+    onTooltipHover?: (isHovering: boolean) => void;
   }
 
-  let { marker, position, containerElement, markerDiameter = 40 }: Props = $props();
+  let { marker, position, containerElement, markerDiameter = 40, onTooltipHover }: Props = $props();
 
   let tooltipElement = $state<HTMLDivElement>();
   let portalContainer: HTMLDivElement | undefined = $state();
   let cleanup: (() => void) | null = null;
+
+  function handleTooltipMouseEnter() {
+    console.log('[MarkerTooltip] Mouse entered tooltip');
+    if (onTooltipHover) {
+      onTooltipHover(true);
+    }
+  }
+
+  function handleTooltipMouseLeave() {
+    console.log('[MarkerTooltip] Mouse left tooltip');
+    if (onTooltipHover) {
+      onTooltipHover(false);
+    }
+  }
 
   // Get the content whether it's from marker.note or marker.tooltip.content
   const getMarkerContent = (marker: any) => {
@@ -168,7 +183,13 @@
 </script>
 
 {#if (markerContent || markerTitle) && position}
-  <div bind:this={tooltipElement} class="marker-tooltip" style="display: none;">
+  <div
+    bind:this={tooltipElement}
+    class="marker-tooltip"
+    style="display: none;"
+    onmouseenter={handleTooltipMouseEnter}
+    onmouseleave={handleTooltipMouseLeave}
+  >
     {#if markerTitle}
       <div class="marker-tooltip__title">{markerTitle}</div>
     {/if}
@@ -183,7 +204,6 @@
     max-width: 400px;
     background: var(--bg);
     padding: 1rem;
-    pointer-events: none;
     border-radius: var(--radius);
     box-shadow: var(--shadow-lg);
     border: 1px solid var(--border);

--- a/packages/ui/src/lib/components/MarkerTooltip/MarkerTooltip.svelte
+++ b/packages/ui/src/lib/components/MarkerTooltip/MarkerTooltip.svelte
@@ -1,0 +1,204 @@
+<script lang="ts">
+  import type { Marker } from '../Stage/components/MarkerLayer/types';
+  import { computePosition, flip, shift, offset, autoUpdate } from '@floating-ui/dom';
+  import { Editor } from '../Editor';
+  import { onMount, onDestroy } from 'svelte';
+
+  interface Props {
+    marker: any | null; // Can be either Marker or HoveredMarker
+    position: { x: number; y: number } | null;
+    containerElement: HTMLElement | null;
+    markerDiameter?: number;
+  }
+
+  let { marker, position, containerElement, markerDiameter = 40 }: Props = $props();
+
+  let tooltipElement = $state<HTMLDivElement>();
+  let portalContainer: HTMLDivElement | undefined = $state();
+  let cleanup: (() => void) | null = null;
+
+  // Get the content whether it's from marker.note or marker.tooltip.content
+  const getMarkerContent = (marker: any) => {
+    if (!marker) return null;
+
+    // Check for marker.note (Marker type)
+    if (marker.note) {
+      return marker.note;
+    }
+
+    // Check for marker.tooltip.content (HoveredMarker type)
+    if (marker.tooltip?.content) {
+      // Parse JSON string back to JSONContent if needed
+      if (typeof marker.tooltip.content === 'string') {
+        try {
+          return JSON.parse(marker.tooltip.content);
+        } catch {
+          return marker.tooltip.content;
+        }
+      }
+      return marker.tooltip.content;
+    }
+
+    return null;
+  };
+
+  // Get the title from either marker.title or marker.tooltip.title
+  const getMarkerTitle = (marker: any) => {
+    if (!marker) return null;
+
+    // Check for marker.title (Marker type)
+    if (marker.title) {
+      return marker.title;
+    }
+
+    // Check for marker.tooltip.title (HoveredMarker type)
+    if (marker.tooltip?.title) {
+      return marker.tooltip.title;
+    }
+
+    return null;
+  };
+
+  let markerContent = $derived(getMarkerContent(marker));
+  let markerTitle = $derived(getMarkerTitle(marker));
+  let markerSize = $derived(marker?.size || 1);
+
+  function createPortalContainer() {
+    const existingContainer = document.getElementById('markerTooltipPortal');
+    if (existingContainer) {
+      portalContainer = existingContainer as HTMLDivElement;
+      return;
+    }
+
+    const container = document.createElement('div');
+    container.id = 'markerTooltipPortal';
+    container.style.position = 'absolute';
+    container.style.top = '0';
+    container.style.left = '0';
+    container.style.width = '0';
+    container.style.height = '0';
+    container.style.pointerEvents = 'none';
+    container.style.zIndex = '10000';
+    document.body.appendChild(container);
+    portalContainer = container;
+  }
+
+  onMount(() => {
+    createPortalContainer();
+  });
+
+  onDestroy(() => {
+    if (cleanup) {
+      cleanup();
+      cleanup = null;
+    }
+
+    if (tooltipElement && portalContainer && portalContainer.contains(tooltipElement)) {
+      portalContainer.removeChild(tooltipElement);
+    }
+
+    if (portalContainer && portalContainer.childNodes.length === 0) {
+      if (document.body.contains(portalContainer)) {
+        document.body.removeChild(portalContainer);
+      }
+    }
+  });
+
+  $effect(() => {
+    if (tooltipElement && position && containerElement && portalContainer) {
+      if (!portalContainer.contains(tooltipElement)) {
+        portalContainer.appendChild(tooltipElement);
+      }
+
+      if (cleanup) {
+        cleanup();
+        cleanup = null;
+      }
+
+      const virtualEl = {
+        getBoundingClientRect() {
+          const rect = containerElement.getBoundingClientRect();
+          const viewportX = rect.left + position.x;
+          const viewportY = rect.top + position.y;
+
+          return {
+            width: 0,
+            height: 0,
+            x: viewportX,
+            y: viewportY,
+            top: viewportY,
+            left: viewportX,
+            right: viewportX,
+            bottom: viewportY
+          };
+        }
+      };
+
+      cleanup = autoUpdate(virtualEl, tooltipElement, async () => {
+        const markerRadius = markerDiameter / 2;
+        const buffer = 10;
+        const dynamicOffset = markerRadius + buffer;
+
+        const { x, y } = await computePosition(virtualEl, tooltipElement, {
+          placement: 'top',
+          middleware: [offset(dynamicOffset), flip(), shift({ padding: 10 })],
+          strategy: 'fixed'
+        });
+
+        Object.assign(tooltipElement.style, {
+          position: 'fixed',
+          left: `${x}px`,
+          top: `${y}px`,
+          pointerEvents: 'auto'
+        });
+      });
+
+      tooltipElement.style.display = 'block';
+    } else if (tooltipElement) {
+      tooltipElement.style.display = 'none';
+    }
+
+    return () => {
+      if (cleanup) {
+        cleanup();
+        cleanup = null;
+      }
+    };
+  });
+</script>
+
+{#if (markerContent || markerTitle) && position}
+  <div bind:this={tooltipElement} class="marker-tooltip" style="display: none;">
+    {#if markerTitle}
+      <div class="marker-tooltip__title">{markerTitle}</div>
+    {/if}
+    {#if markerContent}
+      <Editor content={markerContent} editable={false} />
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .marker-tooltip {
+    max-width: 400px;
+    background: var(--bg);
+    padding: 1rem;
+    pointer-events: none;
+    border-radius: var(--radius);
+    box-shadow: var(--shadow-lg);
+    border: 1px solid var(--border);
+    border-radius: 0.25rem;
+    box-shadow: var(--shadow-3);
+  }
+
+  .marker-tooltip__title {
+    font-weight: 600;
+    font-size: var(--text-md);
+    margin-bottom: 0.5rem;
+    color: var(--fgPrimary);
+  }
+
+  .marker-tooltip__title:last-child {
+    margin-bottom: 0;
+  }
+</style>

--- a/packages/ui/src/lib/components/MarkerTooltip/MarkerTooltip.svelte
+++ b/packages/ui/src/lib/components/MarkerTooltip/MarkerTooltip.svelte
@@ -271,7 +271,7 @@
     font-weight: 600;
     font-size: var(--text-md);
     margin-bottom: 0.5rem;
-    color: var(--fgPrimary);
+    color: var(--fg);
     padding-right: 2rem; /* Make room for pin button */
   }
 

--- a/packages/ui/src/lib/components/MarkerTooltip/MarkerTooltip.svelte
+++ b/packages/ui/src/lib/components/MarkerTooltip/MarkerTooltip.svelte
@@ -243,9 +243,8 @@
 
       cleanup = autoUpdate(virtualEl, tooltipElement!, async () => {
         const markerRadius = markerDiameter / 2;
-        const buffer = 10;
         const arrowSize = 8;
-        const dynamicOffset = markerRadius + buffer + arrowSize;
+        const dynamicOffset = markerRadius + arrowSize;
 
         let bestPlacement = preferredPlacement;
 

--- a/packages/ui/src/lib/components/MarkerTooltip/MarkerTooltip.svelte
+++ b/packages/ui/src/lib/components/MarkerTooltip/MarkerTooltip.svelte
@@ -181,7 +181,7 @@
     container.style.width = '0';
     container.style.height = '0';
     container.style.pointerEvents = 'none';
-    container.style.zIndex = '10000';
+    container.style.zIndex = '1';
     document.body.appendChild(container);
     portalContainer = container;
   }

--- a/packages/ui/src/lib/components/MarkerTooltip/index.ts
+++ b/packages/ui/src/lib/components/MarkerTooltip/index.ts
@@ -1,0 +1,1 @@
+export { default as MarkerTooltip } from './MarkerTooltip.svelte';

--- a/packages/ui/src/lib/components/Stage/components/MarkerLayer/MarkerLayer.svelte
+++ b/packages/ui/src/lib/components/Stage/components/MarkerLayer/MarkerLayer.svelte
@@ -91,14 +91,6 @@
     // Did we click on an existing marker?
     if (closestMarker !== undefined) {
       selectedMarker = closestMarker;
-      console.log('[MarkerLayer] Marker clicked:', {
-        mode: stage.mode,
-        isDM: stage.mode === StageMode.DM,
-        isPlayer: stage.mode === StageMode.Player,
-        markerId: closestMarker.id,
-        markerTitle: closestMarker.title
-      });
-      // Only allow dragging in DM mode
       if (stage.mode === StageMode.DM) {
         isDragging = true;
       }
@@ -107,7 +99,6 @@
       // In player mode, clicking empty space clears selection
       if (stage.mode === StageMode.Player) {
         selectedMarker = null;
-        console.log('[MarkerLayer] Empty space clicked in player mode, clearing selection');
         return;
       }
 
@@ -186,7 +177,6 @@
       clearTimeout(hoverTimer);
       hoverTimer = null;
     }
-    // Add delay before clearing the delayed hover state
     if (hideTimer) {
       clearTimeout(hideTimer);
     }
@@ -206,13 +196,13 @@
     return (
       marker.visibility === MarkerVisibility.Always ||
       (marker.visibility === MarkerVisibility.DM && stage.mode === StageMode.DM) ||
-      (marker.visibility === MarkerVisibility.Hover && stage.mode === StageMode.DM) || // DM can always see Hover markers
+      (marker.visibility === MarkerVisibility.Hover && stage.mode === StageMode.DM) ||
       (marker.visibility === MarkerVisibility.Hover &&
         stage.mode === StageMode.Player &&
-        marker.id === stage.hoveredMarkerId) || // Players see Hover markers when DM hovers
+        marker.id === stage.hoveredMarkerId) ||
       (marker.visibility === MarkerVisibility.Hover &&
         stage.mode === StageMode.Player &&
-        stage.pinnedMarkerIds?.includes(marker.id)) || // Players see Hover markers when pinned
+        stage.pinnedMarkerIds?.includes(marker.id)) ||
       (marker.visibility === MarkerVisibility.Player && stage.mode === StageMode.Player)
     );
   }
@@ -250,28 +240,20 @@
     }
   });
 
-  // Function to keep tooltip visible when hovering over it
   export function maintainHover(maintain: boolean) {
-    console.log('[MarkerLayer] maintainHover called:', maintain, 'mode:', stage.mode);
     if (maintain && stage.mode === StageMode.DM) {
-      // Cancel any pending hide
       cancelHideTimer();
-      console.log('[MarkerLayer] Cancelling hide timer');
     } else if (!maintain && stage.mode === StageMode.DM && !hoveredMarker) {
-      // If not maintaining and not hovering a marker, start hide timer
       clearHoverTimer();
-      console.log('[MarkerLayer] Starting hide timer');
     }
   }
 
   // Export reactive state for hover and drag
   export const markerState = {
     get isHovering() {
-      // In DM mode, use the delayed hover
       if (stage.mode === StageMode.DM) {
         return hoveredMarkerDelayed !== null && hoveredMarkerDelayed !== undefined;
       }
-      // In Player mode, check if there's a hoveredMarkerId from the DM
       return stage.hoveredMarkerId !== null && stage.hoveredMarkerId !== undefined;
     },
     get isDragging() {

--- a/packages/ui/src/lib/components/Stage/components/MarkerLayer/MarkerLayer.svelte
+++ b/packages/ui/src/lib/components/Stage/components/MarkerLayer/MarkerLayer.svelte
@@ -23,7 +23,7 @@
 
   const { props, isActive, display, grid }: Props = $props();
 
-  const stage = getContext<{ mode: StageMode; hoveredMarkerId: string | null }>('stage');
+  const stage = getContext<{ mode: StageMode; hoveredMarkerId: string | null; pinnedMarkerIds: string[] }>('stage');
   const { onMarkerAdded, onMarkerMoved, onMarkerSelected, onMarkerContextMenu, onMarkerHover } =
     getContext<Callbacks>('callbacks');
 
@@ -210,6 +210,9 @@
       (marker.visibility === MarkerVisibility.Hover &&
         stage.mode === StageMode.Player &&
         marker.id === stage.hoveredMarkerId) || // Players see Hover markers when DM hovers
+      (marker.visibility === MarkerVisibility.Hover &&
+        stage.mode === StageMode.Player &&
+        stage.pinnedMarkerIds?.includes(marker.id)) || // Players see Hover markers when pinned
       (marker.visibility === MarkerVisibility.Player && stage.mode === StageMode.Player)
     );
   }
@@ -279,10 +282,15 @@
       if (stage.mode === StageMode.DM) {
         return hoveredMarkerDelayed;
       }
-      // In Player mode, find the marker that matches the DM's hoveredMarkerId
+      // In Player mode, find the marker that matches the DM's hoveredMarkerId or is pinned
       if (stage.hoveredMarkerId) {
         const hoveredMarker = props.marker.markers.find((m) => m.id === stage.hoveredMarkerId);
         return hoveredMarker || null;
+      }
+      // Check for pinned markers
+      if (stage.pinnedMarkerIds && stage.pinnedMarkerIds.length > 0) {
+        const pinnedMarker = props.marker.markers.find((m) => stage.pinnedMarkerIds.includes(m.id));
+        return pinnedMarker || null;
       }
       return null;
     },

--- a/packages/ui/src/lib/components/Stage/components/MarkerLayer/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/MarkerLayer/types.ts
@@ -3,7 +3,8 @@ import type { JSONContent } from '@tiptap/core';
 export enum MarkerVisibility {
   Always = 0,
   DM = 1,
-  Player = 2
+  Player = 2,
+  Hover = 3 // Hidden from players, revealed on DM hover
 }
 
 export enum MarkerShape {
@@ -115,5 +116,6 @@ export interface MarkerLayerExports {
   markerState: {
     isHovering: boolean;
     isDragging: boolean;
+    hoveredMarker: Marker | null;
   };
 }

--- a/packages/ui/src/lib/components/Stage/components/MarkerLayer/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/MarkerLayer/types.ts
@@ -117,5 +117,7 @@ export interface MarkerLayerExports {
     isHovering: boolean;
     isDragging: boolean;
     hoveredMarker: Marker | null;
+    selectedMarker: Marker | null;
   };
+  maintainHover: (maintain: boolean) => void;
 }

--- a/packages/ui/src/lib/components/Stage/components/Scene/Scene.svelte
+++ b/packages/ui/src/lib/components/Stage/components/Scene/Scene.svelte
@@ -461,6 +461,12 @@
     },
     get hoveredMarker() {
       return markerLayer?.markerState?.hoveredMarker ?? null;
+    },
+    get selectedMarker() {
+      return markerLayer?.markerState?.selectedMarker ?? null;
+    },
+    maintainHover: (maintain: boolean) => {
+      markerLayer?.maintainHover?.(maintain);
     }
   };
 

--- a/packages/ui/src/lib/components/Stage/components/Scene/Scene.svelte
+++ b/packages/ui/src/lib/components/Stage/components/Scene/Scene.svelte
@@ -487,14 +487,21 @@
 
   export function getMarkerScreenPosition(marker: any) {
     if (!marker?.position) return null;
+
+    // Create a vector at the marker's local position
     const vector = new THREE.Vector3(marker.position.x, marker.position.y, 0);
-    vector.x += props.scene.offset.x;
-    vector.y += props.scene.offset.y;
-    vector.x *= props.scene.zoom;
-    vector.y *= props.scene.zoom;
+
+    // Apply scene transformations to get world position
+    // The markers are rendered inside a T.Object3D with position and scale transforms
+    vector.x = vector.x * props.scene.zoom + props.scene.offset.x;
+    vector.y = vector.y * props.scene.zoom + props.scene.offset.y;
+
+    // Project world position to screen space
     vector.project(camera.current);
-    let x = (vector.x * 0.5 + 0.5) * $size.width;
-    let y = (-vector.y * 0.5 + 0.5) * $size.height;
+
+    // Convert from normalized device coordinates (-1 to 1) to screen coordinates
+    const x = (vector.x * 0.5 + 0.5) * $size.width;
+    const y = (-vector.y * 0.5 + 0.5) * $size.height;
 
     return { x, y };
   }

--- a/packages/ui/src/lib/components/Stage/components/Scene/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/Scene/types.ts
@@ -60,6 +60,7 @@ export interface SceneExports {
   fill: () => void;
   fit: () => void;
   generateThumbnail: () => Promise<Blob>;
+  getMarkerScreenPosition: (marker: any) => { x: number; y: number } | null;
 
   annotations: {
     clear: (layerId: string) => void;
@@ -86,6 +87,7 @@ export interface SceneExports {
   markers: {
     isHoveringMarker: boolean;
     isDraggingMarker: boolean;
+    hoveredMarker: any | null;
   };
 
   measurement: {

--- a/packages/ui/src/lib/components/Stage/components/Scene/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/Scene/types.ts
@@ -88,7 +88,11 @@ export interface SceneExports {
     isHoveringMarker: boolean;
     isDraggingMarker: boolean;
     hoveredMarker: any | null;
+    selectedMarker: any | null;
+    maintainHover: (maintain: boolean) => void;
   };
+
+  getMarkerSizeInScreenSpace: (markerSize: number) => number;
 
   measurement: {
     getCurrentMeasurement: () => {

--- a/packages/ui/src/lib/components/Stage/components/Stage/Stage.svelte
+++ b/packages/ui/src/lib/components/Stage/components/Stage/Stage.svelte
@@ -154,8 +154,11 @@
     let markerForTooltip = null;
 
     if (props.mode === 0) {
-      // DM mode: use hovered marker
-      markerForTooltip = sceneRef?.markers?.hoveredMarker;
+      // DM mode: check if hovered marker is already pinned
+      const hoveredMarker = sceneRef?.markers?.hoveredMarker;
+      if (hoveredMarker && !pinnedMarkerIds.includes(hoveredMarker.id)) {
+        markerForTooltip = hoveredMarker;
+      }
     } else if (props.mode === 1) {
       // Player mode: Check for DM's broadcast or player's selection (pinned are handled separately)
 

--- a/packages/ui/src/lib/components/Stage/components/Stage/Stage.svelte
+++ b/packages/ui/src/lib/components/Stage/components/Stage/Stage.svelte
@@ -186,5 +186,11 @@
     position={tooltipPosition}
     {containerElement}
     markerDiameter={markerSizeInPixels}
+    onTooltipHover={(isHovering) => {
+      // When hovering tooltip in DM mode, maintain the hover state
+      if (props.mode === 0 && sceneRef?.markers?.maintainHover) {
+        sceneRef.markers.maintainHover(isHovering);
+      }
+    }}
   />
 </div>

--- a/packages/ui/src/lib/components/Stage/components/Stage/Stage.svelte
+++ b/packages/ui/src/lib/components/Stage/components/Stage/Stage.svelte
@@ -58,13 +58,14 @@
   let hoveredMarkerData = $state<any>(null);
   let markerSizeInPixels = $state<number>(40);
 
-  // Store game mode and hovered marker as reactive state which can be referenced by other components
-  let stageContext = $state({ mode: props.mode, hoveredMarkerId });
+  // Store game mode, hovered marker, and pinned markers as reactive state which can be referenced by other components
+  let stageContext = $state({ mode: props.mode, hoveredMarkerId, pinnedMarkerIds });
   setContext('stage', stageContext);
 
   $effect(() => {
     stageContext.mode = props.mode;
     stageContext.hoveredMarkerId = hoveredMarkerId;
+    stageContext.pinnedMarkerIds = pinnedMarkerIds;
   });
 
   setContext('callbacks', callbacks);

--- a/packages/ui/src/lib/components/Stage/components/Stage/Stage.svelte
+++ b/packages/ui/src/lib/components/Stage/components/Stage/Stage.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
-  import { Canvas, T } from '@threlte/core';
+  import { Canvas, T, useThrelte } from '@threlte/core';
   import type { Callbacks, StageProps } from './types';
   import Scene from '../Scene/Scene.svelte';
   import { type SceneExports, SceneLayerOrder } from '../Scene/types';
   import { setContext } from 'svelte';
   import { PerfMonitor } from '@threlte/extras';
+  import { MarkerTooltip } from '../../../MarkerTooltip';
+  import * as THREE from 'three';
 
   import type { CursorData } from './types';
 
@@ -34,18 +36,31 @@
     } | null;
     cursors?: CursorData[];
     trackLocalCursor?: boolean;
+    hoveredMarkerId?: string | null;
   }
 
-  let { props, callbacks, receivedMeasurement = null, cursors = [], trackLocalCursor = false }: Props = $props();
+  let {
+    props,
+    callbacks,
+    receivedMeasurement = null,
+    cursors = [],
+    trackLocalCursor = false,
+    hoveredMarkerId = null
+  }: Props = $props();
 
   let sceneRef: SceneExports;
+  let containerElement = $state<HTMLDivElement>();
+  let tooltipPosition = $state<{ x: number; y: number } | null>(null);
+  let hoveredMarkerData = $state<any>(null);
+  let markerSizeInPixels = $state<number>(40);
 
-  // Store game mode as reactive state which can be referenced by other components
-  let stageContext = $state({ mode: props.mode });
+  // Store game mode and hovered marker as reactive state which can be referenced by other components
+  let stageContext = $state({ mode: props.mode, hoveredMarkerId });
   setContext('stage', stageContext);
 
   $effect(() => {
     stageContext.mode = props.mode;
+    stageContext.hoveredMarkerId = hoveredMarkerId;
   });
 
   setContext('callbacks', callbacks);
@@ -94,9 +109,66 @@
     getCurrentMeasurement: () => sceneRef?.measurement?.getCurrentMeasurement() ?? null,
     isDrawing: () => sceneRef?.measurement?.isDrawing() ?? false
   };
+
+  $effect(() => {
+    const zoom = props.scene.zoom;
+    const gridSpacing = props.grid.spacing;
+    const displayRes = props.display.resolution;
+    const displaySize = props.display.size;
+
+    if (sceneRef?.getMarkerSizeInScreenSpace) {
+      const markerSize = hoveredMarkerData?.size || 1;
+      markerSizeInPixels = sceneRef.getMarkerSizeInScreenSpace(markerSize);
+    }
+  });
+
+  $effect(() => {
+    // In DM mode (mode 0): Show tooltip for hovered marker
+    // In Player mode (mode 1): Show tooltip for DM's broadcast (from hoveredMarkerId) OR player's selected marker
+    let markerForTooltip = null;
+
+    if (props.mode === 0) {
+      // DM mode: use hovered marker
+      markerForTooltip = sceneRef?.markers?.hoveredMarker;
+    } else if (props.mode === 1) {
+      // Player mode: Check for DM's broadcast first (hoveredMarkerId from props)
+      // This is set when DM hovers or selects a Hover visibility marker
+      let dmBroadcastMarker = null;
+      if (hoveredMarkerId) {
+        // Find the marker that matches the DM's broadcast
+        dmBroadcastMarker = props.marker.markers.find((m) => m.id === hoveredMarkerId);
+        console.log('[Stage] Player mode - DM broadcast marker:', {
+          hoveredMarkerId,
+          foundMarker: dmBroadcastMarker?.id,
+          markerTitle: dmBroadcastMarker?.title
+        });
+      }
+
+      const selectedByPlayer = sceneRef?.markers?.selectedMarker;
+      console.log('[Stage] Player mode tooltip check:', {
+        dmBroadcast: dmBroadcastMarker?.id,
+        selectedByPlayer: selectedByPlayer?.id,
+        selectedTitle: selectedByPlayer?.title
+      });
+
+      // Prioritize DM's broadcast over player's selection
+      markerForTooltip = dmBroadcastMarker || selectedByPlayer;
+    }
+
+    if (markerForTooltip && containerElement) {
+      hoveredMarkerData = markerForTooltip;
+      const screenPos = sceneRef?.getMarkerScreenPosition?.(markerForTooltip);
+      if (screenPos) {
+        tooltipPosition = screenPos;
+      }
+    } else {
+      hoveredMarkerData = null;
+      tooltipPosition = null;
+    }
+  });
 </script>
 
-<div style="height: 100%; width: 100%;">
+<div bind:this={containerElement} style="height: 100%; width: 100%; position: relative;">
   <Canvas>
     <T.Mesh scale={[100000, 100000, 1]} layers={[SceneLayerOrder.Background]}>
       <T.PlaneGeometry />
@@ -108,4 +180,11 @@
       <PerfMonitor logsPerSecond={props.debug.loggingRate} anchorX={'right'} anchorY={'bottom'} />
     {/if}
   </Canvas>
+
+  <MarkerTooltip
+    marker={hoveredMarkerData}
+    position={tooltipPosition}
+    {containerElement}
+    markerDiameter={markerSizeInPixels}
+  />
 </div>

--- a/packages/ui/src/lib/components/Stage/components/Stage/Stage.svelte
+++ b/packages/ui/src/lib/components/Stage/components/Stage/Stage.svelte
@@ -134,6 +134,8 @@
   };
 
   $effect(() => {
+    // Update marker size when zoom changes or marker data changes
+    const zoom = props.scene.zoom;
     if (sceneRef?.getMarkerSizeInScreenSpace) {
       const markerSize = hoveredMarkerData?.size || 1;
       markerSizeInPixels = sceneRef.getMarkerSizeInScreenSpace(markerSize);

--- a/packages/ui/src/lib/components/Stage/components/Stage/types.ts
+++ b/packages/ui/src/lib/components/Stage/components/Stage/types.ts
@@ -19,7 +19,7 @@ export interface Callbacks {
   onStageInitialized: () => void;
   onMarkerAdded: (marker: Marker) => void;
   onMarkerMoved: (marker: Marker, position: { x: number; y: number }) => void;
-  onMarkerSelected: (marker: Marker) => void;
+  onMarkerSelected: (marker: Marker | null) => void;
   onMarkerContextMenu: (marker: Marker, event: MouseEvent | TouchEvent) => void;
   onMeasurementStart?: (startPoint: { x: number; y: number }, type: number) => void;
   onMeasurementUpdate?: (
@@ -29,6 +29,7 @@ export interface Callbacks {
   ) => void;
   onMeasurementEnd?: () => void;
   onCursorMove?: (worldPosition: { x: number; y: number; z: number }) => void;
+  onMarkerHover?: (marker: Marker | null) => void;
 }
 
 export enum StageMode {

--- a/packages/ui/src/lib/components/Stage/index.ts
+++ b/packages/ui/src/lib/components/Stage/index.ts
@@ -1,3 +1,4 @@
+export { type HoveredMarker } from '../../types/awareness';
 export { type AnnotationLayerData, type AnnotationsLayerProps } from './components/AnnotationLayer/types';
 export { DrawMode, RenderMode, ToolType } from './components/DrawingLayer/types';
 export { GridType } from './components/GridLayer/types';

--- a/packages/ui/src/lib/types/awareness.ts
+++ b/packages/ui/src/lib/types/awareness.ts
@@ -1,0 +1,17 @@
+export interface HoveredMarker {
+  id: string;
+  position: {
+    x: number;
+    y: number;
+    z: number;
+  };
+  tooltip: {
+    title: string;
+    content: string; // Rich text HTML from TipTap
+    imageUrl?: string;
+  };
+}
+
+export interface MarkerAwarenessState {
+  hoveredMarker?: HoveredMarker;
+}


### PR DESCRIPTION
Markers can now create tooltips, made up of the title and note content from the marker. These tooltips can be "pinned" to appear in the playfield area.

Why?

This is really helpful for large, overlap maps where you might need to mark points of interest.

<img width="1230" height="1420" alt="image" src="https://github.com/user-attachments/assets/7949d74a-56df-4257-88d5-af00b9f770dc" />
