### PR TITLE
Rework drawing controls

### DIFF
--- a/apps/web/src/lib/components/GameSession/AnnotationManager.svelte
+++ b/apps/web/src/lib/components/GameSession/AnnotationManager.svelte
@@ -534,6 +534,7 @@
     position: relative;
     overflow: hidden;
     flex-shrink: 0;
+    background-color: var(--contrastLowest);
   }
 
   .annotationManager__previewImage {

--- a/apps/web/src/lib/components/GameSession/AnnotationManager.svelte
+++ b/apps/web/src/lib/components/GameSession/AnnotationManager.svelte
@@ -355,6 +355,7 @@
             <div
               class="annotationManager__preview"
               style:aspect-ratio={previewAspectRatio}
+              style:transform="rotate({stageProps.scene.rotation}deg)"
               title={annotation.name || 'Annotation layer'}
             >
               {#if thumbnailUrls[annotation.id]}

--- a/apps/web/src/lib/components/GameSession/AnnotationManager.svelte
+++ b/apps/web/src/lib/components/GameSession/AnnotationManager.svelte
@@ -28,13 +28,17 @@
     selectedAnnotationId = $bindable(),
     onAnnotationDeleted,
     onAnnotationUpdated,
-    onAnnotationCreated
+    onAnnotationCreated,
+    handleOpacityChange = $bindable(),
+    handleBrushSizeChange = $bindable()
   }: {
     stageProps: StageProps;
     selectedAnnotationId: string | undefined;
     onAnnotationDeleted?: (annotationId: string) => void;
     onAnnotationUpdated?: (annotation: AnnotationLayerData) => void;
     onAnnotationCreated?: () => void;
+    handleOpacityChange?: (value: number) => void;
+    handleBrushSizeChange?: (value: number) => void;
   } = $props();
 
   // Line width should be reactive to the global state
@@ -98,6 +102,23 @@
     // Save to preferences (debounced)
     setPreferenceDebounced('annotationLineWidth', value);
   };
+
+  // Export handlers for external use (e.g., DrawingSliders)
+  const handleOpacityChangeInternal = (annotationId: string, value: number) => {
+    updateAnnotation(annotationId, { opacity: value });
+  };
+
+  // Bind handlers for external components
+  $effect(() => {
+    const activeLayer = stageProps.annotations.activeLayer;
+    if (activeLayer) {
+      handleOpacityChange = (value: number) => handleOpacityChangeInternal(activeLayer, value);
+      handleBrushSizeChange = handleLineWidthChange;
+    } else {
+      handleOpacityChange = undefined;
+      handleBrushSizeChange = undefined;
+    }
+  });
 
   // Initialize drag and drop composable
   const dragAndDrop = useDragAndDrop<AnnotationLayerData>({

--- a/apps/web/src/lib/components/GameSession/AnnotationManager.svelte
+++ b/apps/web/src/lib/components/GameSession/AnnotationManager.svelte
@@ -43,9 +43,6 @@
     annotationMasks?: Record<string, string | null>;
   } = $props();
 
-  // Line width should be reactive to the global state
-  let lineWidth = $derived(stageProps.annotations.lineWidth || 50);
-
   // Store thumbnail blob URLs for annotations
   let thumbnailUrls = $state<Record<string, string>>({});
 
@@ -103,8 +100,6 @@
       const r = (rgb >> 16) & 255;
       const g = (rgb >> 8) & 255;
       const b = rgb & 255;
-
-      console.log('[Thumbnail] Generating for color:', color, '→ RGB:', { r, g, b });
 
       for (let i = 0; i < binaryMask.length; i++) {
         const idx = i * 4;

--- a/apps/web/src/lib/components/GameSession/AnnotationManager.svelte
+++ b/apps/web/src/lib/components/GameSession/AnnotationManager.svelte
@@ -104,6 +104,8 @@
       const g = (rgb >> 8) & 255;
       const b = rgb & 255;
 
+      console.log('[Thumbnail] Generating for color:', color, '→ RGB:', { r, g, b });
+
       for (let i = 0; i < binaryMask.length; i++) {
         const idx = i * 4;
         pixels[idx] = r;
@@ -362,11 +364,12 @@
                   class="annotationManager__previewImage"
                 />
               {:else if annotation.url}
-                <img
-                  src={annotation.url}
-                  alt={annotation.name || 'Annotation layer preview'}
-                  class="annotationManager__previewImage"
-                />
+                <div
+                  class="annotationManager__previewLegacy"
+                  style:background-color={annotation.color}
+                  style:opacity={annotation.opacity}
+                  style:--mask-url="url({annotation.url})"
+                ></div>
               {:else}
                 <div
                   class="annotationManager__previewEmpty"
@@ -536,6 +539,19 @@
     width: 100%;
     height: 100%;
     object-fit: contain;
+  }
+
+  .annotationManager__previewLegacy {
+    width: 100%;
+    height: 100%;
+    -webkit-mask-image: var(--mask-url);
+    mask-image: var(--mask-url);
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    -webkit-mask-position: center;
+    mask-position: center;
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
   }
 
   .annotationManager__previewEmpty {

--- a/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
+++ b/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
@@ -14,7 +14,8 @@
     addToast,
     ToolType,
     type HoveredMarker,
-    MarkerVisibility
+    MarkerVisibility,
+    DrawingSliders
   } from '@tableslayer/ui';
   import { invalidateAll } from '$app/navigation';
   import { PaneGroup, Pane, PaneResizer, type PaneAPI } from 'paneforge';
@@ -246,6 +247,11 @@
   );
   let selectedMarkerId: string | undefined = $state();
   let selectedAnnotationId: string | undefined = $state();
+
+  // Derive active annotation for drawing sliders
+  let activeAnnotation = $derived(
+    stageProps?.annotations.layers.find((layer) => layer.id === stageProps.annotations.activeLayer)
+  );
 
   // Track which markers were loaded from the database for Y.js sync
   let persistedMarkerIds = $state<Set<string>>(new Set(data.selectedSceneMarkers?.map((marker) => marker.id) || []));
@@ -1518,6 +1524,10 @@
     });
   };
 
+  // Drawing slider handlers - bound from AnnotationManager
+  let handleOpacityChange: ((value: number) => void) | undefined = $state();
+  let handleBrushSizeChange: ((value: number) => void) | undefined = $state();
+
   // Generate random high-contrast colors that complement #d73e2e
   const getRandomAnnotationColor = () => {
     const annotationColors = [
@@ -2635,6 +2645,14 @@
     </PaneResizer>
     <Pane defaultSize={paneLayout?.[1]?.size ?? 70}>
       <div class="stageWrapper" role="presentation">
+        {#if stageProps.activeLayer === MapLayerType.Annotation && activeAnnotation && handleOpacityChange && handleBrushSizeChange}
+          <DrawingSliders
+            opacity={activeAnnotation.opacity}
+            brushSize={stageProps.annotations.lineWidth || 50}
+            onOpacityChange={handleOpacityChange}
+            onBrushSizeChange={handleBrushSizeChange}
+          />
+        {/if}
         <div class={stageClasses} bind:this={stageElement}>
           <PointerInputManager
             {minZoom}
@@ -2736,6 +2754,8 @@
             {onAnnotationDeleted}
             {onAnnotationUpdated}
             {onAnnotationCreated}
+            bind:handleOpacityChange
+            bind:handleBrushSizeChange
           />
         {/key}
       {:else}

--- a/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
+++ b/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
@@ -40,13 +40,7 @@
     useUpdateAnnotationMaskMutation
   } from '$lib/queries';
   import { type ZodIssue } from 'zod';
-  import {
-    IconChevronDown,
-    IconChevronUp,
-    IconChevronLeft,
-    IconChevronRight,
-    IconBoxMultiple1
-  } from '@tabler/icons-svelte';
+  import { IconChevronDown, IconChevronUp, IconChevronLeft, IconChevronRight } from '@tabler/icons-svelte';
   import { navigating } from '$app/state';
   import {
     buildSceneProps,
@@ -2666,11 +2660,13 @@
             opacity={activeAnnotation.opacity}
             brushSize={stageProps.annotations.lineWidth || 50}
             color={activeAnnotation.color}
+            activeLayerIndex={stageProps.annotations.layers.findIndex(
+              (l) => l.id === stageProps.annotations.activeLayer
+            ) + 1}
             onOpacityChange={handleOpacityChange}
             onBrushSizeChange={handleBrushSizeChange}
             onColorChange={handleColorChange}
             onLayersClick={handleToggleAnnotationPanel}
-            layersIcon={IconBoxMultiple1}
           />
         {/if}
         <div class={stageClasses} bind:this={stageElement}>

--- a/packages/ui/src/lib/components/DrawingSliders/DrawingSliders.svelte
+++ b/packages/ui/src/lib/components/DrawingSliders/DrawingSliders.svelte
@@ -1,0 +1,175 @@
+<script lang="ts">
+  interface Props {
+    opacity: number;
+    brushSize: number;
+    onOpacityChange: (value: number) => void;
+    onBrushSizeChange: (value: number) => void;
+  }
+
+  let { opacity, brushSize, onOpacityChange, onBrushSizeChange }: Props = $props();
+
+  // Use quadratic curve for brush size to give more precision to lower values
+  // At 50% slider we want size 50, so we use: size = 0.02 * slider^2
+  // This gives: 0% → 1, 50% → 50, 100% → 200
+  const brushSizeToSlider = (size: number): number => {
+    // Inverse: slider = sqrt(size / 0.02)
+    // Clamp to minimum of 1
+    const clampedSize = Math.max(1, size);
+    return Math.sqrt(clampedSize / 0.02);
+  };
+
+  const sliderToBrushSize = (slider: number): number => {
+    // Quadratic curve: size = 0.02 * slider^2
+    const size = 0.02 * slider * slider;
+    return Math.max(1, Math.round(size));
+  };
+
+  let brushSliderValue = $derived(brushSizeToSlider(brushSize));
+
+  const handleBrushSliderChange = (value: number) => {
+    const actualSize = sliderToBrushSize(value);
+    onBrushSizeChange(actualSize);
+  };
+</script>
+
+<div class="drawingSliders">
+  <div class="drawingSliders__slider">
+    <label class="drawingSliders__label" for="opacity-slider">Opacity</label>
+    <input
+      id="opacity-slider"
+      type="range"
+      class="drawingSliders__input"
+      min="0"
+      max="1"
+      step="0.01"
+      value={opacity}
+      oninput={(e) => onOpacityChange(Number(e.currentTarget.value))}
+      orient="vertical"
+    />
+    <div class="drawingSliders__value">{Math.round(opacity * 100)}%</div>
+  </div>
+
+  <div class="drawingSliders__slider">
+    <label class="drawingSliders__label" for="brush-size-slider">Size</label>
+    <input
+      id="brush-size-slider"
+      type="range"
+      class="drawingSliders__input"
+      min="0"
+      max="100"
+      step="0.1"
+      value={brushSliderValue}
+      oninput={(e) => handleBrushSliderChange(Number(e.currentTarget.value))}
+      orient="vertical"
+    />
+    <div class="drawingSliders__value">{brushSize}</div>
+  </div>
+</div>
+
+<style>
+  .drawingSliders {
+    position: absolute;
+    top: 50%;
+    right: 1rem;
+    transform: translateY(-50%);
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    z-index: 10;
+    pointer-events: auto;
+  }
+
+  .drawingSliders__slider {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    background-color: var(--bg);
+    border: var(--borderThin);
+    border-radius: var(--radius-2);
+    padding: 1rem 0.75rem;
+  }
+
+  .drawingSliders__label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--fgMuted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .drawingSliders__input {
+    writing-mode: vertical-lr;
+    direction: rtl;
+    width: 8px;
+    height: 120px;
+    -webkit-appearance: slider-vertical;
+    appearance: slider-vertical;
+    background: transparent;
+    cursor: pointer;
+  }
+
+  /* Webkit browsers (Chrome, Safari, Edge) */
+  .drawingSliders__input::-webkit-slider-track {
+    width: 8px;
+    background: var(--contrastMedium);
+    border-radius: var(--radius-1);
+  }
+
+  .drawingSliders__input::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 24px;
+    height: 24px;
+    background: var(--fgPrimary);
+    border: 2px solid var(--bg);
+    border-radius: 50%;
+    cursor: grab;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    transition: transform 0.1s ease;
+  }
+
+  .drawingSliders__input::-webkit-slider-thumb:hover {
+    transform: scale(1.1);
+  }
+
+  .drawingSliders__input::-webkit-slider-thumb:active {
+    cursor: grabbing;
+    transform: scale(1.05);
+  }
+
+  /* Firefox */
+  .drawingSliders__input::-moz-range-track {
+    width: 8px;
+    background: var(--contrastMedium);
+    border-radius: var(--radius-1);
+  }
+
+  .drawingSliders__input::-moz-range-thumb {
+    width: 24px;
+    height: 24px;
+    background: var(--fgPrimary);
+    border: 2px solid var(--bg);
+    border-radius: 50%;
+    cursor: grab;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    transition: transform 0.1s ease;
+  }
+
+  .drawingSliders__input::-moz-range-thumb:hover {
+    transform: scale(1.1);
+  }
+
+  .drawingSliders__input::-moz-range-thumb:active {
+    cursor: grabbing;
+    transform: scale(1.05);
+  }
+
+  .drawingSliders__value {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--fg);
+    min-width: 3rem;
+    text-align: center;
+  }
+</style>

--- a/packages/ui/src/lib/components/DrawingSliders/DrawingSliders.svelte
+++ b/packages/ui/src/lib/components/DrawingSliders/DrawingSliders.svelte
@@ -3,29 +3,72 @@
   import { ColorPicker } from '../ColorPicker';
   import { Icon } from '../Icon';
   import { IconButton } from '../Button';
+  import {
+    IconBoxMultiple,
+    IconBoxMultiple1,
+    IconBoxMultiple2,
+    IconBoxMultiple3,
+    IconBoxMultiple4,
+    IconBoxMultiple5,
+    IconBoxMultiple6,
+    IconBoxMultiple7,
+    IconBoxMultiple8,
+    IconBoxMultiple9
+  } from '@tabler/icons-svelte';
   import type { ComponentType } from 'svelte';
 
   interface Props {
     opacity: number;
     brushSize: number;
     color: string;
+    activeLayerIndex: number;
     onOpacityChange: (value: number) => void;
     onBrushSizeChange: (value: number) => void;
     onColorChange: (color: string, opacity: number) => void;
     onLayersClick: () => void;
-    layersIcon: ComponentType;
   }
 
   let {
     opacity,
     brushSize,
     color,
+    activeLayerIndex,
     onOpacityChange,
     onBrushSizeChange,
     onColorChange,
-    onLayersClick,
-    layersIcon
+    onLayersClick
   }: Props = $props();
+
+  $effect(() => {
+    console.log(
+      '[DrawingSliders] Props updated - activeLayerIndex:',
+      activeLayerIndex,
+      'opacity:',
+      opacity,
+      'color:',
+      color
+    );
+  });
+
+  // Select the appropriate icon based on layer count
+  const layerIcons: ComponentType[] = [
+    IconBoxMultiple1,
+    IconBoxMultiple2,
+    IconBoxMultiple3,
+    IconBoxMultiple4,
+    IconBoxMultiple5,
+    IconBoxMultiple6,
+    IconBoxMultiple7,
+    IconBoxMultiple8,
+    IconBoxMultiple9
+  ];
+
+  const layerIcon = $derived.by(() => {
+    // activeLayerIndex is 1-based (1st layer, 2nd layer, etc.)
+    const icon = activeLayerIndex <= 9 && activeLayerIndex > 0 ? layerIcons[activeLayerIndex - 1] : IconBoxMultiple;
+    console.log('[DrawingSliders] Active layer index:', activeLayerIndex, 'Icon:', icon);
+    return icon;
+  });
 
   // Use quadratic curve for brush size to give more precision to lower values
   // At 50% slider we want size 50, so we use: size = 0.02 * slider^2
@@ -105,8 +148,13 @@
     <div class="drawingSliders__value">{brushSize}</div>
   </div>
 
-  <IconButton variant="ghost" onclick={onLayersClick} aria-label="Toggle annotation layers panel">
-    <Icon Icon={layersIcon} size="1.25rem" />
+  <IconButton
+    variant="ghost"
+    onclick={onLayersClick}
+    aria-label="Toggle annotation layers panel"
+    title="Manage drawing layers"
+  >
+    <Icon Icon={layerIcon} size="1.25rem" />
   </IconButton>
 </div>
 
@@ -161,9 +209,8 @@
   .drawingSliders__input::-webkit-slider-thumb {
     -webkit-appearance: none;
     appearance: none;
-    width: 28px;
+    width: 32px;
     height: 14px;
-    margin: 2px;
     background: var(--contrastHigh);
     border: none;
     border-radius: var(--radius-1);
@@ -188,9 +235,8 @@
   }
 
   .drawingSliders__input::-moz-range-thumb {
-    width: 28px;
+    width: 32px;
     height: 14px;
-    margin: 2px;
     background: var(--contrastHigh);
     border: none;
     border-radius: var(--radius-2);

--- a/packages/ui/src/lib/components/DrawingSliders/DrawingSliders.svelte
+++ b/packages/ui/src/lib/components/DrawingSliders/DrawingSliders.svelte
@@ -39,17 +39,6 @@
     onLayersClick
   }: Props = $props();
 
-  $effect(() => {
-    console.log(
-      '[DrawingSliders] Props updated - activeLayerIndex:',
-      activeLayerIndex,
-      'opacity:',
-      opacity,
-      'color:',
-      color
-    );
-  });
-
   // Select the appropriate icon based on layer count
   const layerIcons: ComponentType[] = [
     IconBoxMultiple1,
@@ -65,9 +54,7 @@
 
   const layerIcon = $derived.by(() => {
     // activeLayerIndex is 1-based (1st layer, 2nd layer, etc.)
-    const icon = activeLayerIndex <= 9 && activeLayerIndex > 0 ? layerIcons[activeLayerIndex - 1] : IconBoxMultiple;
-    console.log('[DrawingSliders] Active layer index:', activeLayerIndex, 'Icon:', icon);
-    return icon;
+    return activeLayerIndex <= 9 && activeLayerIndex > 0 ? layerIcons[activeLayerIndex - 1] : IconBoxMultiple;
   });
 
   // Use quadratic curve for brush size to give more precision to lower values
@@ -91,6 +78,18 @@
   const handleBrushSliderChange = (value: number) => {
     const actualSize = sliderToBrushSize(value);
     onBrushSizeChange(actualSize);
+  };
+
+  // Touch event handlers for better mobile support
+  const handleTouchStart = (e: TouchEvent) => {
+    // Prevent default to avoid conflicts with other touch interactions
+    e.stopPropagation();
+  };
+
+  const handleTouchMove = (e: TouchEvent) => {
+    // Prevent scrolling while adjusting sliders
+    e.preventDefault();
+    e.stopPropagation();
   };
 </script>
 
@@ -128,7 +127,8 @@
       step="0.01"
       value={opacity}
       oninput={(e) => onOpacityChange(Number(e.currentTarget.value))}
-      orient="vertical"
+      ontouchstart={handleTouchStart}
+      ontouchmove={handleTouchMove}
     />
     <div class="drawingSliders__value">{Math.round(opacity * 100)}%</div>
   </div>
@@ -143,7 +143,8 @@
       step="0.1"
       value={brushSliderValue}
       oninput={(e) => handleBrushSliderChange(Number(e.currentTarget.value))}
-      orient="vertical"
+      ontouchstart={handleTouchStart}
+      ontouchmove={handleTouchMove}
     />
     <div class="drawingSliders__value">{brushSize}</div>
   </div>
@@ -192,6 +193,7 @@
     appearance: slider-vertical;
     background: transparent;
     cursor: pointer;
+    touch-action: none; /* Prevent default touch behaviors */
   }
 
   /* Webkit browsers (Chrome, Safari, Edge) */

--- a/packages/ui/src/lib/components/DrawingSliders/DrawingSliders.svelte
+++ b/packages/ui/src/lib/components/DrawingSliders/DrawingSliders.svelte
@@ -1,12 +1,31 @@
 <script lang="ts">
+  import { Popover } from '../Popover';
+  import { ColorPicker } from '../ColorPicker';
+  import { Icon } from '../Icon';
+  import { IconButton } from '../Button';
+  import type { ComponentType } from 'svelte';
+
   interface Props {
     opacity: number;
     brushSize: number;
+    color: string;
     onOpacityChange: (value: number) => void;
     onBrushSizeChange: (value: number) => void;
+    onColorChange: (color: string, opacity: number) => void;
+    onLayersClick: () => void;
+    layersIcon: ComponentType;
   }
 
-  let { opacity, brushSize, onOpacityChange, onBrushSizeChange }: Props = $props();
+  let {
+    opacity,
+    brushSize,
+    color,
+    onOpacityChange,
+    onBrushSizeChange,
+    onColorChange,
+    onLayersClick,
+    layersIcon
+  }: Props = $props();
 
   // Use quadratic curve for brush size to give more precision to lower values
   // At 50% slider we want size 50, so we use: size = 0.02 * slider^2
@@ -34,11 +53,33 @@
 
 <div class="drawingSliders">
   <div class="drawingSliders__slider">
-    <label class="drawingSliders__label" for="opacity-slider">Opacity</label>
+    <Popover portal="body">
+      {#snippet trigger()}
+        <button
+          class="drawingSliders__colorSwatch"
+          style:background-color={color}
+          style:opacity
+          aria-label="Change annotation color"
+        ></button>
+      {/snippet}
+      {#snippet content()}
+        <div class="ColorPicker-container">
+          <ColorPicker
+            showOpacity={false}
+            hex={color +
+              Math.round(opacity * 255)
+                .toString(16)
+                .padStart(2, '0')}
+            onUpdate={(colorData) => onColorChange(colorData.hex.slice(0, 7), colorData.rgba.a)}
+          />
+        </div>
+      {/snippet}
+    </Popover>
     <input
       id="opacity-slider"
       type="range"
-      class="drawingSliders__input"
+      class="drawingSliders__input drawingSliders__input--opacity"
+      style="--slider-color: {color}"
       min="0"
       max="1"
       step="0.01"
@@ -50,7 +91,6 @@
   </div>
 
   <div class="drawingSliders__slider">
-    <label class="drawingSliders__label" for="brush-size-slider">Size</label>
     <input
       id="brush-size-slider"
       type="range"
@@ -64,6 +104,10 @@
     />
     <div class="drawingSliders__value">{brushSize}</div>
   </div>
+
+  <IconButton variant="ghost" onclick={onLayersClick} aria-label="Toggle annotation layers panel">
+    <Icon Icon={layersIcon} size="1.25rem" />
+  </IconButton>
 </div>
 
 <style>
@@ -74,28 +118,21 @@
     transform: translateY(-50%);
     display: flex;
     flex-direction: column;
-    gap: 2rem;
+    gap: 1rem;
     z-index: 10;
     pointer-events: auto;
+    background-color: var(--bg);
+    border: var(--borderThin);
+    border-radius: var(--radius-2);
+    padding: 0.5rem 0rem;
+    align-items: center;
   }
 
   .drawingSliders__slider {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 0.5rem;
-    background-color: var(--bg);
-    border: var(--borderThin);
-    border-radius: var(--radius-2);
-    padding: 1rem 0.75rem;
-  }
-
-  .drawingSliders__label {
-    font-size: 0.75rem;
-    font-weight: 600;
-    color: var(--fgMuted);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
+    gap: 1rem;
   }
 
   .drawingSliders__input {
@@ -111,58 +148,58 @@
 
   /* Webkit browsers (Chrome, Safari, Edge) */
   .drawingSliders__input::-webkit-slider-track {
-    width: 8px;
+    width: 32px;
+    height: 120px;
     background: var(--contrastMedium);
     border-radius: var(--radius-1);
+  }
+
+  .drawingSliders__input--opacity::-webkit-slider-track {
+    background: linear-gradient(to top, transparent, var(--slider-color));
   }
 
   .drawingSliders__input::-webkit-slider-thumb {
     -webkit-appearance: none;
     appearance: none;
-    width: 24px;
-    height: 24px;
-    background: var(--fgPrimary);
+    width: 28px;
+    height: 14px;
+    margin: 2px;
+    background: var(--fg);
     border: 2px solid var(--bg);
-    border-radius: 50%;
+    border-radius: var(--radius-1);
     cursor: grab;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-    transition: transform 0.1s ease;
-  }
-
-  .drawingSliders__input::-webkit-slider-thumb:hover {
-    transform: scale(1.1);
   }
 
   .drawingSliders__input::-webkit-slider-thumb:active {
     cursor: grabbing;
-    transform: scale(1.05);
   }
 
   /* Firefox */
   .drawingSliders__input::-moz-range-track {
-    width: 8px;
+    width: 32px;
+    height: 120px;
     background: var(--contrastMedium);
-    border-radius: var(--radius-1);
+    border-radius: var(--radius-2);
+  }
+
+  .drawingSliders__input--opacity::-moz-range-track {
+    background: linear-gradient(to top, transparent, var(--slider-color));
   }
 
   .drawingSliders__input::-moz-range-thumb {
-    width: 24px;
-    height: 24px;
-    background: var(--fgPrimary);
+    width: 28px;
+    height: 14px;
+    margin: 2px;
+    background: var(--fg);
     border: 2px solid var(--bg);
-    border-radius: 50%;
+    border-radius: var(--radius-2);
     cursor: grab;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
-    transition: transform 0.1s ease;
-  }
-
-  .drawingSliders__input::-moz-range-thumb:hover {
-    transform: scale(1.1);
   }
 
   .drawingSliders__input::-moz-range-thumb:active {
     cursor: grabbing;
-    transform: scale(1.05);
   }
 
   .drawingSliders__value {
@@ -171,5 +208,23 @@
     color: var(--fg);
     min-width: 3rem;
     text-align: center;
+  }
+
+  .drawingSliders__colorSwatch {
+    width: 2rem;
+    height: 2rem;
+    border-radius: var(--radius-2);
+    border: 2px solid var(--contrastMedium);
+    cursor: pointer;
+    transition: border-color 0.2s;
+    margin-bottom: 0.5rem;
+  }
+
+  .drawingSliders__colorSwatch:hover {
+    border-color: var(--fgPrimary);
+  }
+
+  :global(.drawingSliders .ColorPicker-container) {
+    padding: 1rem;
   }
 </style>

--- a/packages/ui/src/lib/components/DrawingSliders/DrawingSliders.svelte
+++ b/packages/ui/src/lib/components/DrawingSliders/DrawingSliders.svelte
@@ -150,7 +150,7 @@
   .drawingSliders__input::-webkit-slider-track {
     width: 32px;
     height: 120px;
-    background: var(--contrastMedium);
+    background: var(--contrastLow);
     border-radius: var(--radius-1);
   }
 
@@ -164,11 +164,11 @@
     width: 28px;
     height: 14px;
     margin: 2px;
-    background: var(--fg);
-    border: 2px solid var(--bg);
+    background: var(--contrastHigh);
+    border: none;
     border-radius: var(--radius-1);
     cursor: grab;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 0px 2px rgba(0, 0, 0, 0.2);
   }
 
   .drawingSliders__input::-webkit-slider-thumb:active {
@@ -179,7 +179,7 @@
   .drawingSliders__input::-moz-range-track {
     width: 32px;
     height: 120px;
-    background: var(--contrastMedium);
+    background: var(--contrastLow);
     border-radius: var(--radius-2);
   }
 
@@ -191,11 +191,11 @@
     width: 28px;
     height: 14px;
     margin: 2px;
-    background: var(--fg);
-    border: 2px solid var(--bg);
+    background: var(--contrastHigh);
+    border: none;
     border-radius: var(--radius-2);
     cursor: grab;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    box-shadow: 0 0px 2px rgba(0, 0, 0, 0.2);
   }
 
   .drawingSliders__input::-moz-range-thumb:active {

--- a/packages/ui/src/lib/components/DrawingSliders/index.ts
+++ b/packages/ui/src/lib/components/DrawingSliders/index.ts
@@ -1,0 +1,1 @@
+export { default as DrawingSliders } from './DrawingSliders.svelte';

--- a/packages/ui/src/lib/components/Stage/components/AnnotationLayer/AnnotationMaterial.svelte
+++ b/packages/ui/src/lib/components/Stage/components/AnnotationLayer/AnnotationMaterial.svelte
@@ -27,7 +27,6 @@
   // Use chroma-js to avoid Three.js color space conversions
   function hexToRGB(hex: string): THREE.Vector3 {
     const [r, g, b] = chroma(hex).gl();
-    console.log('[AnnotationMaterial] hexToRGB:', hex, '→', { r, g, b });
     return new THREE.Vector3(r, g, b);
   }
 
@@ -38,7 +37,7 @@
   let annotationMaterial = new THREE.ShaderMaterial({
     uniforms: {
       uMaskTexture: { value: null },
-      uColor: { value: colorUniform },
+      uColor: { value: hexToRGB(props.color) },
       uOpacity: { value: props.opacity },
       uClippingPlanes: new THREE.Uniform(
         clippingPlaneStore.value.map((p) => new THREE.Vector4(p.normal.x, p.normal.y, p.normal.z, p.constant))
@@ -49,11 +48,8 @@
     vertexShader: annotationVertexShader
   });
 
-  console.log('[AnnotationMaterial] Material initialized with color:', props.color, colorUniform);
-
   // Whenever the fog of war props change, we need to update the material
   $effect(() => {
-    console.log('[AnnotationMaterial] Effect running - color:', props.color, 'uniform:', colorUniform);
     // Update the uniform value in-place rather than replacing the object
     annotationMaterial.uniforms.uColor.value.copy(colorUniform);
     annotationMaterial.uniforms.uOpacity.value = props.opacity;
@@ -148,7 +144,6 @@
   initialState={InitialState.Clear}
   {size}
   onRender={(texture) => {
-    console.log('[AnnotationMaterial] Texture rendered for color:', props.color);
     // Ensure color is correct when texture updates
     annotationMaterial.uniforms.uColor.value.copy(colorUniform);
     annotationMaterial.uniforms.uMaskTexture.value = texture;

--- a/packages/ui/src/lib/components/index.ts
+++ b/packages/ui/src/lib/components/index.ts
@@ -5,6 +5,7 @@ export * from './CodeBlock';
 export * from './ColorMode';
 export * from './ColorPicker';
 export * from './ContextMenu';
+export * from './DrawingSliders';
 export * from './Editor';
 export * from './Hr';
 export * from './Icon';


### PR DESCRIPTION
This PR reworks the interface for the drawing controls to be a little easy to use without the need for so many popovers.

- Adds image previews for each drawing layer that respects the scene orientation.
- Fixes the color space being used when rendered in the scene.
- No longer need to have the annotation manager panel open to draw.

<img width="1679" height="1282" alt="image" src="https://github.com/user-attachments/assets/2e86849e-3ee1-4d48-b16e-c020bd6b1dcc" />
