### PR TITLE
Make email (through resend) optional

### DIFF
--- a/apps/web/src/lib/components/GameSession/SceneSelector.svelte
+++ b/apps/web/src/lib/components/GameSession/SceneSelector.svelte
@@ -53,7 +53,7 @@
     party,
     partyData,
     isLocallyReordering = $bindable(false),
-    stripeEnabled = true
+    isStripeEnabled = true
   }: {
     scenes: (SelectScene | (SelectScene & Thumb))[];
     gameSession: SelectGameSession;
@@ -62,7 +62,7 @@
     activeSceneId: string | undefined;
     partyData: ReturnType<typeof usePartyData> | null;
     isLocallyReordering?: boolean;
-    stripeEnabled?: boolean;
+    isStripeEnabled?: boolean;
   } = $props();
 
   let file = $state<FileList | null>(null);
@@ -72,7 +72,7 @@
   let renamingScenes = $state<Record<string, string | null>>({});
   let openScenePopover = $state<string | null>(null);
   let orderedScenes = $state<(SelectScene | (SelectScene & Thumb))[]>([]);
-  let needsToUpgrade = $derived(stripeEnabled && party.plan === 'free' && orderedScenes.length >= 3);
+  let needsToUpgrade = $derived(isStripeEnabled && party.plan === 'free' && orderedScenes.length >= 3);
   let isNewSceneAdded = $state(false);
 
   // Flag to prevent context menu after drag

--- a/apps/web/src/lib/server/config.ts
+++ b/apps/web/src/lib/server/config.ts
@@ -1,0 +1,31 @@
+/**
+ * Configuration utilities
+ * Determines if optional services are enabled based on environment variables
+ */
+
+export const isStripeEnabled = (): boolean => {
+  const stripeApiKey = process.env.STRIPE_API_KEY;
+  const stripeWebhookKey = process.env.STRIPE_WEBHOOK_KEY;
+  const stripePriceIdLifetime = process.env.STRIPE_PRICE_ID_LIFETIME;
+  const stripePriceIdMonthly = process.env.STRIPE_PRICE_ID_MONTHLY;
+  const stripePriceIdYearly = process.env.STRIPE_PRICE_ID_YEARLY;
+
+  return !!(stripeApiKey && stripeWebhookKey && stripePriceIdLifetime && stripePriceIdMonthly && stripePriceIdYearly);
+};
+
+export const getDefaultPartyPlan = (): 'free' | 'lifetime' => {
+  return isStripeEnabled() ? 'free' : 'lifetime';
+};
+
+export const isGoogleOAuthEnabled = (): boolean => {
+  const googleClientId = process.env.GOOGLE_CLIENT_ID;
+  const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET;
+
+  return !!(googleClientId && googleClientSecret);
+};
+
+export const isEmailEnabled = (): boolean => {
+  const resendToken = process.env.RESEND_TOKEN;
+
+  return !!resendToken;
+};

--- a/apps/web/src/lib/server/index.ts
+++ b/apps/web/src/lib/server/index.ts
@@ -1,5 +1,6 @@
 export * from './annotations';
 export * from './auth';
+export * from './config';
 export * from './email';
 export * from './errors';
 export * from './file';

--- a/apps/web/src/lib/server/index.ts
+++ b/apps/web/src/lib/server/index.ts
@@ -11,6 +11,5 @@ export * from './party';
 export * from './partyInvite';
 export * from './profile';
 export * from './scene';
-export * from './stripe/config';
 export * from './user';
 export * from './yjs';

--- a/apps/web/src/lib/server/stripe/config.ts
+++ b/apps/web/src/lib/server/stripe/config.ts
@@ -23,3 +23,9 @@ export const isGoogleOAuthEnabled = (): boolean => {
 
   return !!(googleClientId && googleClientSecret);
 };
+
+export const isEmailEnabled = (): boolean => {
+  const resendToken = process.env.RESEND_TOKEN;
+
+  return !!resendToken;
+};

--- a/apps/web/src/lib/server/stripe/config.ts
+++ b/apps/web/src/lib/server/stripe/config.ts
@@ -1,31 +1,6 @@
 /**
- * Configuration utilities
- * Determines if optional services are enabled based on environment variables
+ * Stripe configuration utilities
+ * Re-exports from main config for backwards compatibility
  */
 
-export const isStripeEnabled = (): boolean => {
-  const stripeApiKey = process.env.STRIPE_API_KEY;
-  const stripeWebhookKey = process.env.STRIPE_WEBHOOK_KEY;
-  const stripePriceIdLifetime = process.env.STRIPE_PRICE_ID_LIFETIME;
-  const stripePriceIdMonthly = process.env.STRIPE_PRICE_ID_MONTHLY;
-  const stripePriceIdYearly = process.env.STRIPE_PRICE_ID_YEARLY;
-
-  return !!(stripeApiKey && stripeWebhookKey && stripePriceIdLifetime && stripePriceIdMonthly && stripePriceIdYearly);
-};
-
-export const getDefaultPartyPlan = (): 'free' | 'lifetime' => {
-  return isStripeEnabled() ? 'free' : 'lifetime';
-};
-
-export const isGoogleOAuthEnabled = (): boolean => {
-  const googleClientId = process.env.GOOGLE_CLIENT_ID;
-  const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET;
-
-  return !!(googleClientId && googleClientSecret);
-};
-
-export const isEmailEnabled = (): boolean => {
-  const resendToken = process.env.RESEND_TOKEN;
-
-  return !!resendToken;
-};
+export { getDefaultPartyPlan, isStripeEnabled } from '../config';

--- a/apps/web/src/lib/server/stripe/config.ts
+++ b/apps/web/src/lib/server/stripe/config.ts
@@ -1,6 +1,0 @@
-/**
- * Stripe configuration utilities
- * Re-exports from main config for backwards compatibility
- */
-
-export { getDefaultPartyPlan, isStripeEnabled } from '../config';

--- a/apps/web/src/routes/(app)/[party]/+page.svelte
+++ b/apps/web/src/routes/(app)/[party]/+page.svelte
@@ -13,7 +13,7 @@
   } from '$lib/components';
 
   let { data } = $props();
-  const { party, gameSessions, isPartyAdmin, invitedEmails, user, stripeEnabled } = $derived(data);
+  const { party, gameSessions, isPartyAdmin, invitedEmails, user, isStripeEnabled } = $derived(data);
   // Map partyRole to role for the PartyMember component
   const members = $derived(
     data.members.map((m) => {
@@ -23,7 +23,7 @@
   );
 
   const partyId = $derived(party.id as string);
-  const needsToUpgrade = $derived(stripeEnabled && party.plan === 'free' && gameSessions.length >= 2);
+  const needsToUpgrade = $derived(isStripeEnabled && party.plan === 'free' && gameSessions.length >= 2);
 </script>
 
 <Head title={party.name} description={`${party.name} on Table Slayer`} />
@@ -51,7 +51,7 @@
       </div>
     </main>
     <aside>
-      {#if isPartyAdmin && stripeEnabled}
+      {#if isPartyAdmin && isStripeEnabled}
         <Title as="h2" size="sm">Patronage</Title>
         <Spacer />
         <PartyUpgrade {party} />

--- a/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
+++ b/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
@@ -75,7 +75,7 @@
     activeScene,
     user,
     brushSize,
-    stripeEnabled
+    isStripeEnabled
   } = $derived(data);
 
   // Helper function to clean stage props before sending to Y.js
@@ -2641,7 +2641,7 @@
         party={currentParty}
         {activeSceneId}
         {partyData}
-        {stripeEnabled}
+        {isStripeEnabled}
         bind:isLocallyReordering
       />
     </Pane>

--- a/apps/web/src/routes/+layout.server.ts
+++ b/apps/web/src/routes/+layout.server.ts
@@ -1,4 +1,4 @@
-import { getPartiesForUser, getUser, isGoogleOAuthEnabled, isStripeEnabled } from '$lib/server';
+import { getPartiesForUser, getUser, isEmailEnabled, isGoogleOAuthEnabled, isStripeEnabled } from '$lib/server';
 import type { LayoutServerLoad } from './$types';
 
 export const load: LayoutServerLoad = async (event) => {
@@ -6,8 +6,16 @@ export const load: LayoutServerLoad = async (event) => {
   const bucketUrl = process.env.CLOUDFLARE_R2_BUCKET_URL || 'https://files.tableslayer.com';
   const stripeEnabled = isStripeEnabled();
   const googleOAuthEnabled = isGoogleOAuthEnabled();
+  const emailEnabled = isEmailEnabled();
 
-  if (!event.locals.user) return { envName, bucketUrl, stripeEnabled, googleOAuthEnabled };
+  if (!event.locals.user)
+    return {
+      envName,
+      bucketUrl,
+      isStripeEnabled: stripeEnabled,
+      isGoogleOAuthEnabled: googleOAuthEnabled,
+      isEmailEnabled: emailEnabled
+    };
 
   const userId = event.locals.user.id;
   try {
@@ -18,8 +26,9 @@ export const load: LayoutServerLoad = async (event) => {
       parties,
       envName,
       bucketUrl,
-      stripeEnabled,
-      googleOAuthEnabled
+      isStripeEnabled: stripeEnabled,
+      isGoogleOAuthEnabled: googleOAuthEnabled,
+      isEmailEnabled: emailEnabled
     };
   } catch (error) {
     console.error('Error fetching user and parties', error);

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -38,7 +38,7 @@
     </div>
   </div>
   <div>
-    {#if !data.stripeEnabled}
+    {#if !data.isStripeEnabled}
       <Text size="1.5rem" color="var(--fgDanger)" weight={600}>Self hosted mode</Text>
       <Spacer size="1rem" />
     {/if}
@@ -57,7 +57,7 @@
     <Spacer size="2rem" />
     <div class="home__buttonGroup">
       <Button href="/signup" class="btn" variant="special" size="lg">
-        {data.stripeEnabled ? 'Try it for free' : 'Sign up'}
+        {data.isStripeEnabled ? 'Try it for free' : 'Sign up'}
       </Button>
       <Button href="/login" class="btn" size="lg">Log in</Button>
     </div>

--- a/apps/web/src/routes/forgot-password/+page.server.ts
+++ b/apps/web/src/routes/forgot-password/+page.server.ts
@@ -1,3 +1,4 @@
+import { isEmailEnabled } from '$lib/server';
 import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
@@ -5,5 +6,7 @@ export const load: PageServerLoad = async (event) => {
   if (event.locals.user) {
     throw redirect(302, '/');
   }
-  return {};
+  return {
+    isEmailEnabled: isEmailEnabled()
+  };
 };

--- a/apps/web/src/routes/forgot-password/+page.svelte
+++ b/apps/web/src/routes/forgot-password/+page.svelte
@@ -1,9 +1,13 @@
 <script lang="ts">
-  import { Input, Button, FormControl, Title, Spacer, Panel } from '@tableslayer/ui';
+  import { Input, Button, FormControl, Title, Spacer, Panel, Text, Link } from '@tableslayer/ui';
   import { Head } from '$lib/components';
   import { useAuthForgotPasswordMutation } from '$lib/queries';
   import { type FormMutationError, handleMutation } from '$lib/factories';
   import { goto } from '$app/navigation';
+
+  let { data } = $props();
+  const { isEmailEnabled } = $derived(data);
+
   let email = $state('');
   let formIsLoading = $state(false);
   let forgotPasswordError = $state<FormMutationError | undefined>(undefined);
@@ -33,15 +37,23 @@
 <Panel class="panel--forgot">
   <Title as="h1" size="md">Forgot password?</Title>
   <Spacer size="2rem" />
-  <form onsubmit={handleForgotPassword}>
-    <FormControl label="Email" name="email" errors={forgotPasswordError && forgotPasswordError.errors}>
-      {#snippet input({ inputProps })}
-        <Input {...inputProps} type="text" bind:value={email} />
-      {/snippet}
-    </FormControl>
+  {#if !isEmailEnabled}
+    <Text>Password reset is not available on this server because email service is not configured.</Text>
     <Spacer />
-    <Button type="submit" isLoading={formIsLoading} disabled={formIsLoading}>Submit</Button>
-  </form>
+    <Text>
+      Please contact your server administrator. Return to <Link href="/login">sign in</Link>.
+    </Text>
+  {:else}
+    <form onsubmit={handleForgotPassword}>
+      <FormControl label="Email" name="email" errors={forgotPasswordError && forgotPasswordError.errors}>
+        {#snippet input({ inputProps })}
+          <Input {...inputProps} type="text" bind:value={email} />
+        {/snippet}
+      </FormControl>
+      <Spacer />
+      <Button type="submit" isLoading={formIsLoading} disabled={formIsLoading}>Submit</Button>
+    </form>
+  {/if}
 </Panel>
 
 <style>

--- a/apps/web/src/routes/healthcheck/+server.ts
+++ b/apps/web/src/routes/healthcheck/+server.ts
@@ -1,5 +1,5 @@
 import { getDatabaseMode } from '$lib/db/app/index';
-import { isGoogleOAuthEnabled, isStripeEnabled } from '$lib/server';
+import { isEmailEnabled, isGoogleOAuthEnabled, isStripeEnabled } from '$lib/server';
 import { json, type RequestHandler } from '@sveltejs/kit';
 
 export const GET: RequestHandler = async () => {
@@ -12,8 +12,9 @@ export const GET: RequestHandler = async () => {
     alloc: process.env.FLY_ALLOC_ID || 'unknown',
     app: process.env.FLY_APP_NAME || 'unknown',
     timestamp: new Date().toISOString(),
-    stripeEnabled: isStripeEnabled(),
-    googleOAuthEnabled: isGoogleOAuthEnabled(),
+    isStripeEnabled: isStripeEnabled(),
+    isGoogleOAuthEnabled: isGoogleOAuthEnabled(),
+    isEmailEnabled: isEmailEnabled(),
     r2BucketUrl: process.env.CLOUDFLARE_R2_BUCKET_URL || 'Not configured',
     partykit: {
       host: partykitHost,

--- a/apps/web/src/routes/login/+page.svelte
+++ b/apps/web/src/routes/login/+page.svelte
@@ -8,7 +8,7 @@
   import { onMount } from 'svelte';
 
   let { data } = $props();
-  const { googleOAuthEnabled } = $derived(data);
+  const { isGoogleOAuthEnabled } = $derived(data);
 
   let email = $state('');
   let password = $state('');
@@ -56,7 +56,7 @@
 <Panel class="login">
   <Title as="h1" size="md" data-testid="signInHeading">Sign in</Title>
   <Spacer />
-  {#if googleOAuthEnabled && data.envName !== 'preview'}
+  {#if isGoogleOAuthEnabled && data.envName !== 'preview'}
     <div>
       <Button href="/login/google" data-sveltekit-preload-data="tap">
         {#snippet start()}

--- a/apps/web/src/routes/login/+page.svelte
+++ b/apps/web/src/routes/login/+page.svelte
@@ -8,7 +8,7 @@
   import { onMount } from 'svelte';
 
   let { data } = $props();
-  const { isGoogleOAuthEnabled } = $derived(data);
+  const { isGoogleOAuthEnabled, isEmailEnabled } = $derived(data);
 
   let email = $state('');
   let password = $state('');
@@ -89,9 +89,8 @@
   </form>
   <Spacer />
   <Text>
-    Need an account? <Link href="/signup">Sign up now</Link> or <Link href="/forgot-password">
-      recover your password
-    </Link>.
+    Need an account? <Link href="/signup">Sign up now</Link>{#if isEmailEnabled}
+      or <Link href="/forgot-password">recover your password</Link>{/if}.
   </Text>
 </Panel>
 

--- a/apps/web/src/routes/signup/+page.svelte
+++ b/apps/web/src/routes/signup/+page.svelte
@@ -17,7 +17,7 @@
   import { goto } from '$app/navigation';
 
   let { data } = $props();
-  const { googleOAuthEnabled } = $derived(data);
+  const { isGoogleOAuthEnabled, isEmailEnabled } = $derived(data);
 
   let email = $state('');
   let password = $state('');
@@ -40,7 +40,9 @@
         signupError = error;
       },
       onSuccess: () => {
-        goto('/verify-email');
+        // If email is disabled, users are auto-verified so go straight to their party
+        // Otherwise, send them to verify their email
+        goto(isEmailEnabled ? '/verify-email' : '/');
       },
       toastMessages: {
         success: { title: 'Welcome to Table Slayer!' },
@@ -57,7 +59,7 @@
 <Panel class="panel--signup">
   <Title as="h1" size="md">Create an account</Title>
   <Spacer />
-  {#if googleOAuthEnabled && data.envName !== 'preview'}
+  {#if isGoogleOAuthEnabled && data.envName !== 'preview'}
     <div>
       <Button href="/login/google" data-sveltekit-preload-data="tap">
         {#snippet start()}

--- a/apps/web/src/routes/verify-email/+page.server.ts
+++ b/apps/web/src/routes/verify-email/+page.server.ts
@@ -1,6 +1,6 @@
 import { db } from '$lib/db/app';
 import { emailVerificationCodesTable } from '$lib/db/app/schema';
-import { getUser } from '$lib/server';
+import { getUser, isEmailEnabled } from '$lib/server';
 import { isWithinExpirationDate } from '$lib/utils';
 import { redirect } from '@sveltejs/kit';
 import { eq } from 'drizzle-orm';
@@ -14,6 +14,7 @@ export const load: PageServerLoad = async (event) => {
   const userId = event.locals.user.id;
   const user = await getUser(userId);
   const isVerified = user?.emailVerified ?? false;
+  const emailEnabled = isEmailEnabled();
 
   if (isVerified) {
     throw redirect(302, '/profile');
@@ -30,6 +31,7 @@ export const load: PageServerLoad = async (event) => {
   return {
     user,
     isWithinExpiration,
-    isVerified
+    isVerified,
+    emailEnabled
   };
 };

--- a/apps/web/src/routes/verify-email/+page.svelte
+++ b/apps/web/src/routes/verify-email/+page.svelte
@@ -10,7 +10,7 @@
   import { goto } from '$app/navigation';
 
   let { data } = $props();
-  const { user } = data;
+  const { user, emailEnabled } = data;
 
   let isChangingEmail = $state(false);
   let formIsLoading = $state(false);
@@ -90,7 +90,15 @@
 
 <Panel class="verify">
   <div>
-    {#if !isChangingEmail}
+    {#if !emailEnabled}
+      <Title as="h1" size="md">Email verification disabled</Title>
+      <Spacer />
+      <Text>Email service is not configured on this server. Your account has been automatically verified.</Text>
+      <Spacer />
+      <Text>
+        Return to <Link href="/profile">your profile</Link>.
+      </Text>
+    {:else if !isChangingEmail}
       {#if data.isVerified}
         <Title as="h1" size="md">Your email is verified</Title>
       {:else if data.isWithinExpiration}


### PR DESCRIPTION
- Makes the naming of config functions the same `stripeEnabled` -> `isStripeEnabled`
- Makes resend optional. If it isn't used
  - Emails don't go out during signup
  - Emails don't go out during invites
  - Forgot password won't work