### PR TITLE
Re-establish websockets in playfield on reconnect

### DIFF
--- a/apps/web/src/lib/changelog/2026-04.md
+++ b/apps/web/src/lib/changelog/2026-04.md
@@ -1,0 +1,3 @@
+#### Fixes
+
+- Fixed an issue where the playfield cursor would stop updating from the editor after periods of inactivity. [#424](https://github.com/Siege-Perilous/tableslayer/pull/424)

--- a/apps/web/src/lib/changelog/2026-04.md
+++ b/apps/web/src/lib/changelog/2026-04.md
@@ -1,3 +1,3 @@
 #### Fixes
 
-- Fixed an issue where the playfield cursor would stop updating from the editor after periods of inactivity. [#424](https://github.com/Siege-Perilous/tableslayer/pull/424)
+- Fixed an issue where the playfield cursor would stop updating from the editor after periods of inactivity. Added visibility/focus handlers and a periodic sync check to keep the connection alive on always-on displays. [#424](https://github.com/Siege-Perilous/tableslayer/pull/424)

--- a/apps/web/src/lib/changelog/2026-04.md
+++ b/apps/web/src/lib/changelog/2026-04.md
@@ -1,3 +1,3 @@
 #### Fixes
 
-- Fixed an issue where the playfield cursor would stop updating from the editor after periods of inactivity. Added visibility/focus handlers and a periodic sync check to keep the connection alive on always-on displays. [#424](https://github.com/Siege-Perilous/tableslayer/pull/424)
+- Fixed an issue where the playfield cursor would stop updating from the editor after periods of inactivity or when switching to a scene in a different game session. [#424](https://github.com/Siege-Perilous/tableslayer/pull/424)

--- a/apps/web/src/routes/(app)/[party]/play/+page@.svelte
+++ b/apps/web/src/routes/(app)/[party]/play/+page@.svelte
@@ -120,6 +120,7 @@
   let currentTemporaryLayerId: string | null = null;
   let temporaryDrawingTimer: ReturnType<typeof setInterval> | null = null;
   let resetLayerTimer: ReturnType<typeof setTimeout> | null = null;
+  let connectionSyncTimer: ReturnType<typeof setInterval> | null = null;
 
   // Persist button state
   let showPersistButton = $state(false);
@@ -1354,6 +1355,15 @@
       }
     }, 1000);
 
+    // Set up periodic sync check to keep the Y.js connection alive
+    // This helps recover from stale WebSocket connections that don't trigger disconnect events
+    connectionSyncTimer = setInterval(() => {
+      if (partyData && !isUnmounting) {
+        devLog('playfield', 'Periodic connection sync check');
+        partyData.forceSyncCheck();
+      }
+    }, 30000); // Every 30 seconds
+
     return () => {
       isUnmounting = true;
       isMounted = false;
@@ -1374,6 +1384,11 @@
       // Clean up temporary drawing timer
       if (temporaryDrawingTimer) {
         clearInterval(temporaryDrawingTimer);
+      }
+
+      // Clean up connection sync timer
+      if (connectionSyncTimer) {
+        clearInterval(connectionSyncTimer);
       }
 
       // Cursor cleanup is handled by Y.js awareness automatically

--- a/apps/web/src/routes/(app)/[party]/play/+page@.svelte
+++ b/apps/web/src/routes/(app)/[party]/play/+page@.svelte
@@ -2226,6 +2226,40 @@
   // $inspect(stageProps); // Commented out to prevent performance issues
 </script>
 
+<svelte:document
+  onvisibilitychange={() => {
+    // When tab becomes visible again after being hidden, trigger a sync check
+    if (!document.hidden && partyData) {
+      devLog('playfield', 'Tab became visible, triggering sync check');
+      partyData.forceSyncCheck();
+    }
+  }}
+/>
+<svelte:window
+  onfocus={() => {
+    // Trigger Y.js sync check when regaining focus to catch any missed cursor/measurement updates
+    if (partyData) {
+      devLog('playfield', 'Window regained focus, triggering sync check');
+      // Small delay to ensure Y.js has had time to reconnect if needed
+      setTimeout(async () => {
+        if (!partyData) return;
+
+        partyData.forceSyncCheck();
+
+        // Invalidate to refresh data from server if connection was stale
+        if (!isInvalidating) {
+          isInvalidating = true;
+          try {
+            await invalidateAll();
+          } finally {
+            isInvalidating = false;
+          }
+        }
+      }, 200);
+    }
+  }}
+/>
+
 <Head title={party.name} description={`${party.name} on Table Slayer`} />
 
 <!-- Y.js is disabled in playfield to prevent conflicts with editor -->

--- a/apps/web/src/routes/(app)/[party]/play/+page@.svelte
+++ b/apps/web/src/routes/(app)/[party]/play/+page@.svelte
@@ -2173,11 +2173,17 @@
               // Reinitialize with new game session
               const partySlug = page.params.party;
               if (partySlug) {
+                // Clean up old subscription before creating new one
+                if (unsubscribeYjs) {
+                  (unsubscribeYjs as () => void)();
+                  unsubscribeYjs = null;
+                }
+
                 initializePartyDataManager(partySlug, user.id, newGameSessionId, data.partykitHost);
                 partyData = usePartyData();
 
-                // Resubscribe to Y.js changes
-                partyData.subscribe(() => {
+                // Resubscribe to Y.js changes with full cursor/measurement handling
+                unsubscribeYjs = partyData.subscribe(() => {
                   if (isUnmounting || isInvalidating) return;
 
                   const updatedPartyState = partyData!.getPartyState();
@@ -2185,6 +2191,44 @@
                     isPaused: updatedPartyState.isPaused,
                     activeSceneId: updatedPartyState.activeSceneId
                   };
+
+                  // Update cursors from Y.js awareness
+                  const yjsCursors = partyData!.getCursors();
+                  const activeCursorKeys = new Set(Object.keys(yjsCursors));
+                  const newCursors = { ...cursors };
+                  for (const cursorKey of Object.keys(cursors)) {
+                    if (!activeCursorKeys.has(cursorKey)) {
+                      delete newCursors[cursorKey];
+                    }
+                  }
+                  cursors = newCursors;
+
+                  Object.entries(yjsCursors).forEach(([cursorKey, cursorData]) => {
+                    cursors = {
+                      ...cursors,
+                      [cursorKey]: {
+                        worldPosition: cursorData.worldPosition || { x: 0, y: 0, z: 0 },
+                        userId: cursorData.userId,
+                        color: cursorData.color,
+                        label: cursorData.label,
+                        lastMoveTime: cursorData.lastMoveTime || Date.now(),
+                        fadedOut: false
+                      }
+                    };
+                  });
+
+                  // Update measurements from Y.js awareness
+                  measurements = partyData!.getMeasurements();
+
+                  // Update temporary layers from Y.js awareness
+                  const manager = getPartyDataManager();
+                  if (manager) {
+                    temporaryLayers = getTemporaryLayers(manager);
+                  }
+
+                  // Update hovered marker from Y.js awareness
+                  const hoveredMarker = partyData!.getHoveredMarker();
+                  hoveredMarkerId = hoveredMarker?.id ?? null;
 
                   // Update scene data
                   if (updatedPartyState.activeSceneId) {
@@ -2195,7 +2239,7 @@
                   }
                 });
 
-                devLog('playfield', 'Y.js reinitialized for new game session');
+                devLog('playfield', 'Y.js reinitialized for new game session with full cursor handling');
               }
             }
 

--- a/packages/stage/package.json
+++ b/packages/stage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableslayer/stage",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "private": true,
   "license": "FSL-1.1-ALv2",
   "repository": {

--- a/packages/stage/src/lib/components/MarkerTooltip/MarkerTooltip.svelte
+++ b/packages/stage/src/lib/components/MarkerTooltip/MarkerTooltip.svelte
@@ -72,14 +72,42 @@
     }
   }
 
+  // Check if TipTap content is empty (only contains empty paragraphs)
+  const isTipTapContentEmpty = (content: unknown): boolean => {
+    if (!content) return true;
+
+    // Handle JSON TipTap content
+    if (typeof content === 'object' && content !== null) {
+      const doc = content as { type?: string; content?: Array<{ type?: string; content?: unknown[] }> };
+      if (doc.type === 'doc' && Array.isArray(doc.content)) {
+        // Empty if no content blocks, or only empty paragraphs
+        if (doc.content.length === 0) return true;
+        return doc.content.every(
+          (block) => block.type === 'paragraph' && (!block.content || block.content.length === 0)
+        );
+      }
+    }
+
+    // Handle HTML string content
+    if (typeof content === 'string') {
+      // Strip HTML tags and check if there's any text content
+      const textContent = content.replace(/<[^>]*>/g, '').trim();
+      return textContent.length === 0;
+    }
+
+    return false;
+  };
+
   const getMarkerContent = (marker: MarkerData | null) => {
     if (!marker) return null;
 
     if (marker.note) {
+      if (isTipTapContentEmpty(marker.note)) return null;
       return marker.note;
     }
 
     if (marker.tooltip?.content) {
+      if (isTipTapContentEmpty(marker.tooltip.content)) return null;
       if (typeof marker.tooltip.content === 'string') {
         try {
           return JSON.parse(marker.tooltip.content);

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tableslayer/ui
 
+## 0.1.17
+
+### Patch Changes
+
+- Fix tooltip rendering for markers
+
 ## 0.1.16
 
 ### Patch Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableslayer/ui",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "license": "FSL-1.1-ALv2",
   "repository": {
     "type": "git",

--- a/packages/ui/src/lib/components/MarkerTooltip/MarkerTooltip.svelte
+++ b/packages/ui/src/lib/components/MarkerTooltip/MarkerTooltip.svelte
@@ -72,14 +72,42 @@
     }
   }
 
+  // Check if TipTap content is empty (only contains empty paragraphs)
+  const isTipTapContentEmpty = (content: unknown): boolean => {
+    if (!content) return true;
+
+    // Handle JSON TipTap content
+    if (typeof content === 'object' && content !== null) {
+      const doc = content as { type?: string; content?: Array<{ type?: string; content?: unknown[] }> };
+      if (doc.type === 'doc' && Array.isArray(doc.content)) {
+        // Empty if no content blocks, or only empty paragraphs
+        if (doc.content.length === 0) return true;
+        return doc.content.every(
+          (block) => block.type === 'paragraph' && (!block.content || block.content.length === 0)
+        );
+      }
+    }
+
+    // Handle HTML string content
+    if (typeof content === 'string') {
+      // Strip HTML tags and check if there's any text content
+      const textContent = content.replace(/<[^>]*>/g, '').trim();
+      return textContent.length === 0;
+    }
+
+    return false;
+  };
+
   const getMarkerContent = (marker: MarkerData | null) => {
     if (!marker) return null;
 
     if (marker.note) {
+      if (isTipTapContentEmpty(marker.note)) return null;
       return marker.note;
     }
 
     if (marker.tooltip?.content) {
+      if (isTipTapContentEmpty(marker.tooltip.content)) return null;
       if (typeof marker.tooltip.content === 'string') {
         try {
           return JSON.parse(marker.tooltip.content);


### PR DESCRIPTION
Occasionally the playfield will disconnect the cursor after some downtime. This should reconnect when those issues happen.

Also fixes a small rendering issue for marker tooltips.