### PR TITLE
Update timestamp of partydata on save, fallback for lights from yjs

### DIFF
--- a/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
+++ b/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
@@ -2659,6 +2659,9 @@
       // Always release the save lock and reset flags - use captured saveSceneId
       if (partyData) {
         partyData.releaseActiveSaver(saveSceneId, saveSuccess);
+        if (saveSuccess) {
+          partyData.updateSceneLastUpdated(saveSceneId, Date.now());
+        }
       }
       isSaving = false;
 

--- a/apps/web/src/routes/(app)/[party]/play/+page@.svelte
+++ b/apps/web/src/routes/(app)/[party]/play/+page@.svelte
@@ -890,6 +890,11 @@
             );
           })()
         },
+        // Ensure light property exists with defaults if Y.js data is incomplete
+        light: {
+          ...StageDefaultProps.light,
+          ...yjsSceneData.stageProps.light
+        },
         // Merge Y.js annotations (permanent) with temporary layers from Y.js awareness
         annotations: (() => {
           const yjsLayers = yjsSceneData.stageProps.annotations?.layers || [];


### PR DESCRIPTION
- Tries to make the "syncing" toast more useful, by updating the timestamp in partydata on save. This prevents overeager drift checks.
- Adds a fallback to add an empty lights array if yjs comes back undefined (likely from older scenes).