### PR TITLE
Add undo/redo to scene editor

### DIFF
--- a/apps/web/src/lib/changelog/2026-06.md
+++ b/apps/web/src/lib/changelog/2026-06.md
@@ -2,6 +2,10 @@
 
 The editor and playfield now share a live, Figma-style sync system. Edits — fog, drawings, markers, lights, and scene settings — appear on the playfield almost instantly and save automatically the moment you make them, so there's no more save delay and no risk of losing work by closing a tab. Multiple editors can work on the same scene at once without overwriting each other, and switching the active scene no longer reloads the playfield. If your connection drops, Table Slayer warns you and syncs everything back up when you reconnect. [#448](https://github.com/Siege-Perilous/tableslayer/pull/448)
 
+#### Undo and redo in the editor
+
+The editor now supports undo and redo with Ctrl + Z and Ctrl + Shift + Z (Cmd on Mac). Walk back fog strokes, drawings, marker moves, deletions, and scene setting changes. [#449](https://github.com/Siege-Perilous/tableslayer/pull/449)
+
 #### Fixes
 
 - Scene links now use a stable address that doesn't change when scenes are reordered. Old links redirect automatically. [#448](https://github.com/Siege-Perilous/tableslayer/pull/448)

--- a/apps/web/src/lib/components/GameSession/Shortcuts.svelte
+++ b/apps/web/src/lib/components/GameSession/Shortcuts.svelte
@@ -3,13 +3,18 @@
   import { Icon, Button, Hr, Popover } from '@tableslayer/ui';
   import { onMount } from 'svelte';
 
-  let hasTouchSupport = false;
+  let hasTouchSupport = $state(false);
+  let isMac = $state(false);
 
   onMount(() => {
     hasTouchSupport = navigator.maxTouchPoints > 0 || 'ontouchstart' in document.documentElement;
+    isMac = /mac/i.test(navigator.platform);
   });
 
   const shortcuts = $derived([
+    { label: 'Undo', shortcut: isMac ? 'Cmd + Z' : 'Ctrl + Z' },
+    { label: 'Redo', shortcut: isMac ? 'Cmd + Shift + Z' : 'Ctrl + Shift + Z' },
+    { divider: true },
     { label: 'Brush size', shortcut: 'Mouse wheel' },
     { label: 'Erase brush', shortcut: 'E' },
     { label: 'Add brush', shortcut: 'Shift + E' },
@@ -90,12 +95,13 @@
   .shortcut__listItem {
     display: flex;
     justify-content: space-between;
-    gap: 4rem;
-    padding: 0.5rem;
+    gap: 2.5rem;
+    padding: 0.25rem 0.5rem;
     white-space: nowrap;
+    font-size: 0.875rem;
   }
   .shortcut__listDivider {
-    padding: 0.5rem 0;
+    padding: 0.25rem 0;
   }
   .shortcut__listItem:hover {
     background: var(--contrastLow);
@@ -103,7 +109,7 @@
   .shortcut__key {
     color: var(--fgMuted);
     font-family: var(--font-mono);
-    font-size: 0.875rem;
+    font-size: 0.75rem;
   }
 
   @container stageWrapper (max-width: 768px) {

--- a/apps/web/src/lib/realtime/SessionDocClient.svelte.ts
+++ b/apps/web/src/lib/realtime/SessionDocClient.svelte.ts
@@ -7,6 +7,7 @@ import {
   getAnnotationMask,
   getFogMask,
   getPartyState,
+  getScenesMap,
   getSceneSnapshot,
   isDocHydrated,
   listScenes,
@@ -42,8 +43,12 @@ export class SessionDocClient {
   readonly partyDoc = new Y.Doc();
   /** Identity tag for this client's transactions. */
   readonly origin: object = { client: 'SessionDocClient' };
+  /** Origin for system writes (thumbnails etc.) — excluded from undo tracking. */
+  readonly systemOrigin: object = { client: 'SessionDocClient', system: true };
 
   readonly write: SessionWriter;
+  /** Writer for system-initiated changes that must never land on the undo stack. */
+  readonly systemWrite: SessionWriter;
   readonly party: PartyWriter;
   readonly presence: PresenceChannel;
   readonly gameSessionId: string;
@@ -56,6 +61,8 @@ export class SessionDocClient {
   });
   /** True once both rooms have synced and the server has hydrated the session doc. */
   ready = $state(false);
+  canUndo = $state(false);
+  canRedo = $state(false);
 
   #sceneRevs = $state<Record<string, number>>({});
   #listRev = $state(0);
@@ -66,6 +73,7 @@ export class SessionDocClient {
   #partyCache: { rev: number; state: PartyState } | null = null;
   #changeListeners = new Set<(changes: SceneChange[]) => void>();
 
+  #undoManager: Y.UndoManager | null = null;
   #gameSessionProvider: YPartyKitProvider;
   #partyProvider: YPartyKitProvider;
   #gameSessionSynced = false;
@@ -78,6 +86,7 @@ export class SessionDocClient {
     this.userId = options.userId;
 
     this.write = createSessionWriter(this.doc, this.origin);
+    this.systemWrite = createSessionWriter(this.doc, this.systemOrigin);
     this.party = createPartyWriter(this.partyDoc, this.origin);
 
     this.#gameSessionProvider = new YPartyKitProvider(options.partykitHost, options.gameSessionId, this.doc, {
@@ -184,6 +193,57 @@ export class SessionDocClient {
   }
 
   // -------------------------------------------------------------------------
+  // Undo/redo — a per-scene Y.UndoManager tracking only this client's origin,
+  // so undo reverts your own edits and never another collaborator's. Each undo
+  // stack item can pin prior mask bytes against GC, hence the stack cap.
+  // -------------------------------------------------------------------------
+
+  static readonly #UNDO_STACK_LIMIT = 100;
+
+  /** Scope undo history to one scene (or null to disable). Clears prior history. */
+  setUndoScope(sceneId: string | null) {
+    this.#undoManager?.destroy();
+    this.#undoManager = null;
+    this.canUndo = false;
+    this.canRedo = false;
+    if (!sceneId) return;
+
+    const scene = getScenesMap(this.doc).get(sceneId);
+    if (!scene) {
+      console.warn(`[realtime] undo scope dropped — scene ${sceneId} not in doc`);
+      return;
+    }
+
+    const undoManager = new Y.UndoManager(scene, {
+      trackedOrigins: new Set([this.origin])
+    });
+    const refresh = () => {
+      if (undoManager.undoStack.length > SessionDocClient.#UNDO_STACK_LIMIT) {
+        undoManager.undoStack.splice(0, undoManager.undoStack.length - SessionDocClient.#UNDO_STACK_LIMIT);
+      }
+      this.canUndo = undoManager.canUndo();
+      this.canRedo = undoManager.canRedo();
+    };
+    undoManager.on('stack-item-added', refresh);
+    undoManager.on('stack-item-popped', refresh);
+    undoManager.on('stack-cleared', refresh);
+    this.#undoManager = undoManager;
+  }
+
+  undo() {
+    this.#undoManager?.undo();
+  }
+
+  redo() {
+    this.#undoManager?.redo();
+  }
+
+  /** Close the current capture group so the next edit starts a new undo step. */
+  stopCapturing() {
+    this.#undoManager?.stopCapturing();
+  }
+
+  // -------------------------------------------------------------------------
   // Imperative reads + change subscription (for canvas mask application etc.)
   // -------------------------------------------------------------------------
 
@@ -205,6 +265,8 @@ export class SessionDocClient {
   }
 
   destroy() {
+    this.#undoManager?.destroy();
+    this.#undoManager = null;
     this.presence.destroy();
     this.#changeListeners.clear();
     this.#gameSessionProvider.destroy();

--- a/apps/web/src/lib/realtime/docSchema.test.ts
+++ b/apps/web/src/lib/realtime/docSchema.test.ts
@@ -447,6 +447,7 @@ describe('undo/redo (Y.UndoManager semantics)', () => {
     // no-op for that key — the newer remote value survives. Undo never reverts
     // another collaborator's work, even on the same field.
     expect(zoomA).toBe(3);
+    disconnect();
   });
 });
 

--- a/apps/web/src/lib/realtime/docSchema.test.ts
+++ b/apps/web/src/lib/realtime/docSchema.test.ts
@@ -302,9 +302,9 @@ describe('classifySceneEvents', () => {
     writer.setFogMask('s1', new Uint8Array([1]));
 
     expect(changes).toEqual([
-      { sceneId: 's1', part: 'settings', keys: ['gridOpacity'], childId: undefined, remote: false },
-      { sceneId: 's1', part: 'markers', keys: ['positionX'], childId: 'm1', remote: false },
-      { sceneId: 's1', part: 'fogMask', keys: ['fogMask'], remote: false }
+      { sceneId: 's1', part: 'settings', keys: ['gridOpacity'], childId: undefined, remote: false, undoRedo: false },
+      { sceneId: 's1', part: 'markers', keys: ['positionX'], childId: 'm1', remote: false, undoRedo: false },
+      { sceneId: 's1', part: 'fogMask', keys: ['fogMask'], remote: false, undoRedo: false }
     ]);
   });
 
@@ -317,8 +317,25 @@ describe('classifySceneEvents', () => {
 
     createSessionWriter(a, 'clientA').setAnnotationMask('s1', 'a1', new Uint8Array([5]));
 
-    expect(changesB).toEqual([{ sceneId: 's1', part: 'annotations', keys: ['mask'], childId: 'a1', remote: true }]);
+    expect(changesB).toEqual([
+      { sceneId: 's1', part: 'annotations', keys: ['mask'], childId: 'a1', remote: true, undoRedo: false }
+    ]);
     disconnect();
+  });
+
+  it('flags undo/redo transactions while keeping them local', () => {
+    const doc = hydratedDoc();
+    const undoManager = new Y.UndoManager(doc.getMap('scenes').get('s1') as Y.Map<unknown>, {
+      trackedOrigins: new Set(['me'])
+    });
+    createSessionWriter(doc, 'me').setSceneSettings('s1', { gridOpacity: 0.1 });
+
+    const changes = collect(doc);
+    undoManager.undo();
+
+    expect(changes).toEqual([
+      { sceneId: 's1', part: 'settings', keys: ['gridOpacity'], childId: undefined, remote: false, undoRedo: true }
+    ]);
   });
 
   it('does not emit events for writes that do not change values', () => {
@@ -328,6 +345,108 @@ describe('classifySceneEvents', () => {
     createSessionWriter(doc, 'me').setSceneSettings('s1', { gridOpacity: 0.8, name: 'Scene s1' });
 
     expect(changes).toEqual([]);
+  });
+});
+
+describe('undo/redo (Y.UndoManager semantics)', () => {
+  const sceneUndoManager = (doc: Y.Doc, sceneId: string, origin: unknown) =>
+    new Y.UndoManager(doc.getMap('scenes').get(sceneId) as Y.Map<unknown>, {
+      trackedOrigins: new Set([origin])
+    });
+
+  it('undoes and redoes a settings change, converging across live clients', () => {
+    const a = hydratedDoc();
+    const b = new Y.Doc();
+    syncOnce(a, b);
+    const disconnect = connect(a, b);
+    const undoManager = sceneUndoManager(a, 's1', 'me');
+
+    createSessionWriter(a, 'me').setSceneSettings('s1', { gridOpacity: 0.25 });
+    expect(undoManager.canUndo()).toBe(true);
+
+    undoManager.undo();
+    expect(getSceneSnapshot(a, 's1')!.settings.gridOpacity).toBe(0.8);
+    expect(getSceneSnapshot(b, 's1')!.settings.gridOpacity).toBe(0.8);
+
+    undoManager.redo();
+    expect(getSceneSnapshot(a, 's1')!.settings.gridOpacity).toBe(0.25);
+    expect(getSceneSnapshot(b, 's1')!.settings.gridOpacity).toBe(0.25);
+    disconnect();
+  });
+
+  it('ignores remote and untracked-origin (system) transactions', () => {
+    const a = hydratedDoc();
+    const b = new Y.Doc();
+    syncOnce(a, b);
+    const disconnect = connect(a, b);
+    const undoManager = sceneUndoManager(a, 's1', 'me');
+
+    createSessionWriter(b, 'them').setSceneSettings('s1', { name: 'Remote rename' });
+    createSessionWriter(a, 'system').setSceneSettings('s1', { mapThumbLocation: 'thumb.png' });
+
+    expect(undoManager.canUndo()).toBe(false);
+    disconnect();
+  });
+
+  it('restores a deleted marker with all of its fields', () => {
+    const doc = hydratedDoc();
+    const undoManager = sceneUndoManager(doc, 's1', 'me');
+
+    createSessionWriter(doc, 'me').deleteMarker('s1', 'm2');
+    expect(getSceneSnapshot(doc, 's1')!.markers.map((m) => m.id)).not.toContain('m2');
+
+    undoManager.undo();
+    const restored = getSceneSnapshot(doc, 's1')!.markers.find((m) => m.id === 'm2');
+    expect(restored?.positionX).toBe(10);
+  });
+
+  it('restores the previous fog mask bytes', () => {
+    const doc = hydratedDoc();
+    const undoManager = sceneUndoManager(doc, 's1', 'me');
+    const writer = createSessionWriter(doc, 'me');
+
+    writer.setFogMask('s1', new Uint8Array([5, 5]));
+    undoManager.undo();
+    expect(getFogMask(doc, 's1')).toEqual(new Uint8Array([1, 2, 3, 4]));
+    undoManager.redo();
+    expect(getFogMask(doc, 's1')).toEqual(new Uint8Array([5, 5]));
+  });
+
+  it('merges rapid writes into one step and splits on stopCapturing', () => {
+    const doc = hydratedDoc();
+    const undoManager = sceneUndoManager(doc, 's1', 'me');
+    const writer = createSessionWriter(doc, 'me');
+
+    writer.setSceneSettings('s1', { mapZoom: 2 });
+    writer.setSceneSettings('s1', { mapZoom: 4 }); // within captureTimeout — merges
+    undoManager.stopCapturing();
+    writer.setSceneSettings('s1', { mapZoom: 8 });
+
+    expect(undoManager.undoStack).toHaveLength(2);
+    undoManager.undo();
+    expect(getSceneSnapshot(doc, 's1')!.settings.mapZoom).toBe(4);
+    undoManager.undo();
+    expect(getSceneSnapshot(doc, 's1')!.settings.mapZoom).toBe(1);
+  });
+
+  it('pins the same-field reconciliation: undo does not clobber a newer remote write', () => {
+    const a = hydratedDoc();
+    const b = new Y.Doc();
+    syncOnce(a, b);
+    const disconnect = connect(a, b);
+    const undoManager = sceneUndoManager(a, 's1', 'me');
+
+    createSessionWriter(a, 'me').setSceneSettings('s1', { mapZoom: 2 });
+    createSessionWriter(b, 'them').setSceneSettings('s1', { mapZoom: 3 });
+    undoManager.undo();
+
+    const zoomA = getSceneSnapshot(a, 's1')!.settings.mapZoom;
+    const zoomB = getSceneSnapshot(b, 's1')!.settings.mapZoom;
+    expect(zoomA).toBe(zoomB);
+    // The remote write already displaced the tracked item, so undoing it is a
+    // no-op for that key — the newer remote value survives. Undo never reverts
+    // another collaborator's work, even on the same field.
+    expect(zoomA).toBe(3);
   });
 });
 

--- a/apps/web/src/lib/realtime/docSchema.ts
+++ b/apps/web/src/lib/realtime/docSchema.ts
@@ -330,6 +330,7 @@ const SCENE_PARTS: ReadonlySet<string> = new Set(['settings', 'markers', 'lights
 export const classifySceneEvents = (events: Y.YEvent<Y.Map<unknown>>[], transaction: Y.Transaction): SceneChange[] => {
   const changes: SceneChange[] = [];
   const remote = !transaction.local;
+  const undoRedo = transaction.origin instanceof Y.UndoManager;
 
   for (const event of events) {
     const path = event.path;
@@ -337,13 +338,13 @@ export const classifySceneEvents = (events: Y.YEvent<Y.Map<unknown>>[], transact
 
     if (path.length === 0) {
       // Scenes added/removed at the top level
-      changes.push({ sceneId: keys[0] ?? '', part: 'scenes', keys, remote });
+      changes.push({ sceneId: keys[0] ?? '', part: 'scenes', keys, remote, undoRedo });
     } else if (path.length === 1) {
       // A key set directly on a scene map (fogMask, or a collection map replaced)
       const sceneId = String(path[0]);
       for (const key of keys) {
         if (SCENE_PARTS.has(key)) {
-          changes.push({ sceneId, part: key as ScenePart, keys: [key], remote });
+          changes.push({ sceneId, part: key as ScenePart, keys: [key], remote, undoRedo });
         }
       }
     } else if (SCENE_PARTS.has(String(path[1]))) {
@@ -356,7 +357,8 @@ export const classifySceneEvents = (events: Y.YEvent<Y.Map<unknown>>[], transact
         part,
         keys,
         childId: path.length >= 3 ? String(path[2]) : undefined,
-        remote
+        remote,
+        undoRedo
       });
     }
   }

--- a/apps/web/src/lib/realtime/types.ts
+++ b/apps/web/src/lib/realtime/types.ts
@@ -157,4 +157,7 @@ export interface SceneChange {
   childId?: string;
   /** False when this client's own transaction produced the change. */
   remote: boolean;
+  /** True when a local Y.UndoManager produced the change (local, but the canvas
+   *  must re-apply masks exactly as it does for remote changes). */
+  undoRedo: boolean;
 }

--- a/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
+++ b/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
@@ -93,6 +93,13 @@
     }
   });
 
+  // Undo history follows the selected scene; switching scenes clears it
+  $effect(() => {
+    if (session.ready && session.client && selectedSceneId) {
+      session.client.setUndoScope(selectedSceneId);
+    }
+  });
+
   const scenes = $derived(session.ready && session.client ? session.client.scenes() : data.scenes);
   const partyState = $derived(
     session.ready && session.client
@@ -1032,6 +1039,16 @@
       return;
     }
 
+    if ((event.ctrlKey || event.metaKey) && !event.altKey) {
+      const key = event.key.toLowerCase();
+      if (key === 'z' || key === 'y') {
+        event.preventDefault();
+        if (key === 'y' || event.shiftKey) session.client?.redo();
+        else session.client?.undo();
+        return;
+      }
+    }
+
     const previousControl = activeControl;
     const newActiveControl = handleKeyCommands(event, stageProps, activeControl, stage, handleSelectActiveControl);
     activeControl = newActiveControl;
@@ -1072,7 +1089,13 @@
   });
 </script>
 
-<svelte:document onkeydown={handleKeydown} bind:activeElement />
+<!-- Every new pointer gesture starts a new undo step (capture phase: fires before
+     stage/panel handlers write, so the previous capture group closes first) -->
+<svelte:document
+  onkeydown={handleKeydown}
+  onpointerdowncapture={() => session.client?.stopCapturing()}
+  bind:activeElement
+/>
 <svelte:window bind:innerWidth />
 <Head title={gameSession.name} description={`${gameSession.name} on Table Slayer`} />
 

--- a/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
+++ b/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
@@ -1043,8 +1043,14 @@
       const key = event.key.toLowerCase();
       if (key === 'z' || key === 'y') {
         event.preventDefault();
-        if (key === 'y' || event.shiftKey) session.client?.redo();
-        else session.client?.undo();
+        if (!session.client) return;
+        if (key === 'y' || event.shiftKey) {
+          if (session.client.canRedo) session.client.redo();
+          else addToast({ data: { title: 'Nothing to redo', type: 'info' } });
+        } else {
+          if (session.client.canUndo) session.client.undo();
+          else addToast({ data: { title: 'Nothing to undo', type: 'info' } });
+        }
         return;
       }
     }

--- a/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/useEditorSession.svelte.ts
+++ b/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/useEditorSession.svelte.ts
@@ -92,11 +92,11 @@ export class EditorSession {
         this.#scheduleThumbnail(change.sceneId);
       }
 
-      if (!change.remote || change.sceneId !== selectedSceneId) continue;
+      if ((!change.remote && !change.undoRedo) || change.sceneId !== selectedSceneId) continue;
 
-      // Remote fog changes apply straight to the canvas (own commits are
-      // excluded by transaction identity, not timing). Annotation masks are
-      // declarative layer props and need no handling here.
+      // Remote and undo/redo fog changes apply straight to the canvas (own
+      // commits are excluded by transaction identity, not timing). Annotation
+      // masks are declarative layer props and need no handling here.
       const stage = this.#options.getStage();
       if (!stage) continue;
       if (change.part === 'fogMask' && !stage.fogOfWar?.isDrawing()) {
@@ -131,7 +131,8 @@ export class EditorSession {
       const currentUrl = client.scene(sceneId)?.settings.mapThumbLocation ?? null;
       const result = await this.#options.uploadThumbnail(blob, sceneId, currentUrl);
       if (result?.location) {
-        client.write.setSceneSettings(sceneId, { mapThumbLocation: result.location });
+        // System origin: a thumbnail write must never become a Ctrl+Z step
+        client.systemWrite.setSceneSettings(sceneId, { mapThumbLocation: result.location });
         devLog('editor', `Updated scene thumbnail: ${result.location}`);
       }
     } catch (error) {

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,4 +6,5 @@ This folder contains documentation for various architecture patterns in Table Sl
 - **grid-system-architecture.md** - How the grid system works
 - **playwright-testing-guide.md** - How to write and run Playwright end-to-end tests
 - **stage-performance-guide.md** - Performance patterns, GPU memory management, and optimization techniques for the Stage component
+- **undo-redo-architecture.md** - Editor undo/redo via Y.UndoManager on the realtime doc
 - **yjs-sync-architecture.md** - Real-time sync architecture using Yjs

--- a/docs/undo-redo-architecture.md
+++ b/docs/undo-redo-architecture.md
@@ -1,0 +1,106 @@
+# Editor undo/redo architecture
+
+How the editor's undo/redo works: a per-scene `Y.UndoManager` on top of the realtime doc
+(see `yjs-sync-architecture.md`), tracking only this client's transactions. Spec and design
+rationale live in `spec/editor-undo-redo.md`. Editor-only by design — the play route is
+primarily a receiver and never constructs an undo scope.
+
+## Mental model
+
+`Y.UndoManager` is not a snapshot rollback; the doc only moves forward. It watches
+transactions whose `origin` is in its `trackedOrigins` set, records the inverse of each
+(items inserted/deleted), and `undo()` applies that inverse as a **new transaction**. The
+undo therefore propagates to other clients and the PartyKit persister exactly like any other
+edit — no server, persistence, or play-route changes were needed.
+
+Reconciliation properties (pinned by tests in
+`apps/web/src/lib/realtime/docSchema.test.ts`, `undo/redo` suite):
+
+- **Per-user.** Each client tracks only its own `SessionDocClient.origin`. Ctrl+Z never
+  reverts another editor's or a player's work.
+- **Concurrent-safe across fields.** The granular per-field Y.Map schema means undoing your
+  change leaves remote edits to other fields untouched.
+- **Same-field race is safe.** If a remote peer rewrites the same field after your change,
+  your undo is a no-op for that key — their item already displaced yours, so their newer
+  value survives.
+- **Deletes restore fully.** Undoing a marker/annotation delete restores the entire row
+  (Y.UndoManager re-inserts deleted subtrees), masks included.
+- **Session-lifetime only.** The stack is in-memory; refresh or scene switch clears it. This
+  is Ctrl+Z, not version history.
+
+## Components
+
+### `SessionDocClient` (`apps/web/src/lib/realtime/SessionDocClient.svelte.ts`)
+
+Owns the `Y.UndoManager` and exposes the whole surface:
+
+- `setUndoScope(sceneId | null)` — destroys any prior manager and creates one scoped to the
+  selected scene's Y.Map with `trackedOrigins = new Set([this.origin])`. The default 500ms
+  `captureTimeout` merges throttled drag/slider transactions into one undo step. Warns and
+  leaves undo disabled if the scene is not in the doc (matches the writer convention).
+- `undo()` / `redo()` / `stopCapturing()` — thin delegates.
+- `canUndo` / `canRedo` — reactive `$state`, refreshed from the manager's
+  `stack-item-added` / `stack-item-popped` / `stack-cleared` events. Available for toolbar
+  buttons (currently keyboard-only).
+- **Stack cap (100).** Every stack item pins its deleted items against Y.js GC — for fog and
+  annotation steps that means the prior RLE mask bytes. The cap trims the oldest entries on
+  add so long painting sessions don't grow memory unboundedly.
+- `systemOrigin` + `systemWrite` — a second `SessionWriter` whose origin is **not** tracked.
+  Used for system-initiated writes that must never become a Ctrl+Z step (currently the
+  thumbnail `mapThumbLocation` write in `EditorSession`).
+
+### Change classification (`docSchema.ts` → `types.ts`)
+
+`SceneChange.undoRedo` is true when `transaction.origin instanceof Y.UndoManager`. This
+exists for one reason: undo transactions are **local** (`remote: false`), but the fog mask
+lives on the GPU canvas and is only re-applied imperatively for non-own changes. Without the
+flag, undoing a fog stroke would revert the doc but never repaint the canvas — and the stale
+canvas would re-commit the undone mask on the next stroke end.
+
+### `EditorSession` (`useEditorSession.svelte.ts`)
+
+Applies fog masks to the canvas when `change.remote || change.undoRedo` (same `isDrawing()`
+guard as remote changes — an in-progress stroke wins and re-commits on stroke end).
+Annotation masks need no handling: they are declarative layer props, so the snapshot rebuild
+repaints them. Thumbnail regeneration after undo happens naturally and is desired (undo
+changes are local, which schedules the idle capture).
+
+### Editor page (`+page.svelte`)
+
+- An `$effect` calls `setUndoScope(selectedSceneId)` once `session.ready` — history follows
+  the selected scene and resets on navigation.
+- `handleKeydown`: Ctrl/Cmd+Z → undo, Ctrl/Cmd+Shift+Z or Ctrl+Y → redo. Runs after the
+  input-focus guard so text fields keep native browser undo.
+- A capture-phase `pointerdown` on the document calls `stopCapturing()` — every new pointer
+  gesture starts a new undo step, so quick consecutive actions don't merge into one.
+
+## Data flow of an undo
+
+```
+Ctrl+Z → client.undo() → UndoManager applies inverse transaction (origin = the manager)
+  → scenes observer → classifySceneEvents { remote: false, undoRedo: true }
+      → revision counters bump → snapshots re-derive → buildRenderProps → Stage (declarative)
+      → EditorSession re-applies fog mask to canvas (imperative, undoRedo path)
+  → provider syncs the update → other editors / play apply it as an ordinary remote change
+  → PartyKit persister marks the scene dirty → debounced DB write
+```
+
+## Out of scope (v1) and how to extend
+
+- **Scene-level operations** (create/delete in `SceneSelector`) happen on the parent scenes
+  map, outside the per-scene scope, and are not undoable. To add "undo scene delete", scope a
+  second UndoManager to the scenes map itself and route only top-level events to it — the
+  restore semantics already work (deleted subtrees come back whole).
+- **Edits to non-selected scenes** (rename/reorder from the scene list) are only captured
+  when they target the selected scene. Accepted inconsistency, documented in the spec.
+- **Toolbar buttons**: bind `client.canUndo` / `client.canRedo` — already reactive.
+- **Version history** ("restore the session to an hour ago") is a different feature
+  (Y.js snapshots), not an UndoManager extension.
+
+## Testing
+
+`docSchema.test.ts` (`undo/redo (Y.UndoManager semantics)`) covers: undo/redo convergence
+across live clients, untracked remote/system origins, full marker restoration after delete,
+fog mask byte restoration, capture merging vs `stopCapturing` splitting, and the same-field
+remote-overwrite race. If a yjs upgrade changes any reconciliation behavior, these tests are
+the tripwire.


### PR DESCRIPTION
Table Slayer's scene editor now allows undo redo within the current scene. This mostly comes for free with https://github.com/Siege-Perilous/tableslayer/pull/448