### PR TITLE
Light and weather now respect map bounds

### DIFF
--- a/apps/web/src/lib/changelog/2026-06.md
+++ b/apps/web/src/lib/changelog/2026-06.md
@@ -9,3 +9,4 @@ The editor now supports undo and redo with Ctrl + Z and Ctrl + Shift + Z (Cmd on
 #### Fixes
 
 - Scene links now use a stable address that doesn't change when scenes are reordered. Old links redirect automatically. [#448](https://github.com/Siege-Perilous/tableslayer/pull/448)
+- Weather and light effects now stay within the bounds of the map, matching how fog behaves, instead of spilling onto the empty area around it. [#450](https://github.com/Siege-Perilous/tableslayer/pull/450)

--- a/packages/stage/src/lib/components/Stage/components/LightLayer/LightToken.svelte
+++ b/packages/stage/src/lib/components/Stage/components/LightLayer/LightToken.svelte
@@ -8,6 +8,7 @@
   import type { GridLayerProps } from '../GridLayer/types';
   import type { DisplayProps } from '../Stage/types';
   import { createLightMaterial, getStyleIndex } from './lightShader';
+  import { mapClippingPlaneStore } from '../../helpers/clippingPlaneStore.svelte';
 
   interface Props {
     light: Light;
@@ -66,10 +67,12 @@
     lightMaterial.uniforms.uStyle.value = getStyleIndex(light.style);
     lightMaterial.uniforms.uColor.value = new THREE.Color(light.color);
     lightMaterial.uniforms.uSelected.value = isSelected || isHovered;
-    // Update position, size, and display bounds for clipping
-    lightMaterial.uniforms.uLightPosition.value.set(light.position.x, light.position.y);
     lightMaterial.uniforms.uLightSize.value = lightSize;
-    lightMaterial.uniforms.uDisplayBounds.value.set(display.resolution.x / 2, display.resolution.y / 2);
+  });
+
+  // Constrain the light glow to the map bounds
+  $effect(() => {
+    lightMaterial.clippingPlanes = mapClippingPlaneStore.value;
   });
 
   onDestroy(() => {
@@ -79,7 +82,7 @@
 
 <T.Group position={[light.position.x, light.position.y, 0]} scale={[lightSize, lightSize, 1]}>
   <T.Mesh renderOrder={SceneLayerOrder.Light} layers={[SceneLayer.Main]}>
-    <T.ShaderMaterial args={[lightMaterial]} attach="material" />
+    <T.ShaderMaterial is={lightMaterial} attach="material" />
     <T.PlaneGeometry args={[1, 1]} />
   </T.Mesh>
 </T.Group>

--- a/packages/stage/src/lib/components/Stage/components/LightLayer/lightShader.ts
+++ b/packages/stage/src/lib/components/Stage/components/LightLayer/lightShader.ts
@@ -3,11 +3,15 @@ import { LightStyle } from './types';
 
 // Vertex shader - simple passthrough with UV
 export const lightVertexShader = /* glsl */ `
+  #include <clipping_planes_pars_vertex>
+
   varying vec2 vUv;
 
   void main() {
     vUv = uv;
-    gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
+    vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+    gl_Position = projectionMatrix * mvPosition;
+    #include <clipping_planes_vertex>
   }
 `;
 
@@ -19,6 +23,8 @@ export const lightVertexShader = /* glsl */ `
 export const lightFragmentShader = /* glsl */ `
   precision highp float;
 
+  #include <clipping_planes_pars_fragment>
+
   varying vec2 vUv;
 
   uniform float uTime;
@@ -28,9 +34,7 @@ export const lightFragmentShader = /* glsl */ `
   uniform int uStyle;
   uniform vec3 uColor;
   uniform bool uSelected;
-  uniform vec2 uLightPosition;
   uniform float uLightSize;
-  uniform vec2 uDisplayBounds;
 
   // Hash function for noise
   vec2 hash(vec2 p) {
@@ -101,14 +105,7 @@ export const lightFragmentShader = /* glsl */ `
   }
 
   void main() {
-    // Calculate world position of this fragment
-    vec2 localOffset = (vUv - 0.5) * uLightSize;
-    vec2 worldPos = uLightPosition + localOffset;
-
-    // Clip to display bounds
-    if (abs(worldPos.x) > uDisplayBounds.x || abs(worldPos.y) > uDisplayBounds.y) {
-      discard;
-    }
+    #include <clipping_planes_fragment>
 
     // Center UV coordinates (-0.5 to 0.5)
     vec2 uv = vUv - 0.5;
@@ -789,13 +786,12 @@ export const createLightMaterial = (style: LightStyle, color: THREE.Color): THRE
       uStyle: { value: getStyleIndex(style) },
       uColor: { value: color },
       uSelected: { value: false },
-      uLightPosition: { value: new THREE.Vector2(0, 0) },
-      uLightSize: { value: 1.0 },
-      uDisplayBounds: { value: new THREE.Vector2(960, 540) }
+      uLightSize: { value: 1.0 }
     },
     transparent: true,
     blending: THREE.AdditiveBlending,
     depthWrite: false,
-    side: THREE.DoubleSide
+    side: THREE.DoubleSide,
+    clipping: true
   });
 };

--- a/packages/stage/src/lib/components/Stage/components/Scene/Scene.svelte
+++ b/packages/stage/src/lib/components/Stage/components/Scene/Scene.svelte
@@ -17,7 +17,12 @@
   import { getLUT } from './luts';
   import { type Callbacks, type StageProps } from '../Stage/types';
   import { MapLayerType, type MapLayerExports } from '../MapLayer/types';
-  import { clippingPlaneStore, updateClippingPlanes } from '../../helpers/clippingPlaneStore.svelte';
+  import {
+    clippingPlaneStore,
+    updateClippingPlanes,
+    updateMapClippingPlanes
+  } from '../../helpers/clippingPlaneStore.svelte';
+  import type { Size } from '../../types';
   import { beginFrame, endFrame, startTiming, endTiming, logMetrics } from '../../helpers/performanceMetrics.svelte';
   import { debugState } from '../../helpers/debugState.svelte';
   import { getGridCellSize as getGridCellSizeHelper } from '../../helpers/grid';
@@ -85,6 +90,7 @@
   let mapLayer: MapLayerExports;
   let markerLayer: MarkerLayerExports;
   let measurementLayer: MeasurementLayerExports | null = $state(null);
+  let mapSize: Size | null = $state(null);
   let needsResize = true;
   let loadingState = SceneLoadingState.LoadingMap;
 
@@ -169,6 +175,11 @@
   $effect(() => {
     updateClippingPlanes(props.scene, props.display);
     untrack(() => (renderer.clippingPlanes = clippingPlaneStore.value));
+  });
+
+  // Clipping planes that constrain weather and light effects to the map bounds
+  $effect(() => {
+    updateMapClippingPlanes(props.scene, props.map, mapSize, props.display);
   });
 
   // Update needsResize when map URL changes
@@ -591,7 +602,8 @@
       callbacks.onStageLoading();
       setLoadingState(SceneLoadingState.LoadingMap);
     }}
-    onMapLoaded={() => {
+    onMapLoaded={(_mapUrl, size) => {
+      mapSize = size;
       needsResize = true;
       if (loadingState === SceneLoadingState.LoadingMap) {
         setLoadingState(SceneLoadingState.Resizing);

--- a/packages/stage/src/lib/components/Stage/components/WeatherLayer/WeatherLayer.svelte
+++ b/packages/stage/src/lib/components/Stage/components/WeatherLayer/WeatherLayer.svelte
@@ -5,6 +5,7 @@
   import { WeatherType, type WeatherLayerPreset } from './types';
   import ParticleSystem from '../ParticleSystem/ParticleSystem.svelte';
   import type { StageProps } from '../Stage/types';
+  import { mapClippingPlaneStore } from '../../helpers/clippingPlaneStore.svelte';
 
   import SnowPreset from './presets/SnowPreset';
   import RainPreset from './presets/RainPreset';
@@ -40,6 +41,11 @@
     map: renderTarget.texture,
     transparent: true,
     blending: THREE.NormalBlending
+  });
+
+  // Constrain the weather to the map bounds
+  $effect(() => {
+    quadMaterial.clippingPlanes = mapClippingPlaneStore.value;
   });
 
   onMount(() => {

--- a/packages/stage/src/lib/components/Stage/helpers/clippingPlaneStore.svelte.ts
+++ b/packages/stage/src/lib/components/Stage/helpers/clippingPlaneStore.svelte.ts
@@ -1,6 +1,8 @@
 import * as THREE from 'three';
+import type { MapLayerProps } from '../components/MapLayer/types';
 import type { SceneLayerProps } from '../components/Scene/types';
 import type { DisplayProps } from '../components/Stage/types';
+import type { Size } from '../types';
 
 export const clippingPlaneStore: { value: THREE.Plane[] } = $state({
   value: [
@@ -11,18 +13,66 @@ export const clippingPlaneStore: { value: THREE.Plane[] } = $state({
   ]
 });
 
+export const mapClippingPlaneStore: { value: THREE.Plane[] } = $state({
+  value: [
+    new THREE.Plane(new THREE.Vector3(-1, 0, 0)),
+    new THREE.Plane(new THREE.Vector3(1, 0, 0)),
+    new THREE.Plane(new THREE.Vector3(0, 1, 0)),
+    new THREE.Plane(new THREE.Vector3(0, -1, 0))
+  ]
+});
+
+// Builds world-space clipping planes for a rectangle defined in scene-local
+// coordinates (center, rotation in radians, half extents), accounting for the
+// scene's offset and zoom
+const rectClippingPlanes = (
+  sceneProps: SceneLayerProps,
+  center: { x: number; y: number },
+  rotation: number,
+  halfExtents: { x: number; y: number }
+) => {
+  const { x: offsetX, y: offsetY } = sceneProps.offset;
+  const zoom = sceneProps.zoom;
+  const axisX = new THREE.Vector3(Math.cos(rotation), Math.sin(rotation), 0);
+  const axisY = new THREE.Vector3(-Math.sin(rotation), Math.cos(rotation), 0);
+  const centerAlongX = center.x * axisX.x + center.y * axisX.y;
+  const centerAlongY = center.x * axisY.x + center.y * axisY.y;
+  const offsetAlongX = offsetX * axisX.x + offsetY * axisX.y;
+  const offsetAlongY = offsetX * axisY.x + offsetY * axisY.y;
+
+  return [
+    new THREE.Plane(axisX.clone().negate(), zoom * (halfExtents.x + centerAlongX) + offsetAlongX),
+    new THREE.Plane(axisX, zoom * (halfExtents.x - centerAlongX) - offsetAlongX),
+    new THREE.Plane(axisY.clone().negate(), zoom * (halfExtents.y + centerAlongY) + offsetAlongY),
+    new THREE.Plane(axisY, zoom * (halfExtents.y - centerAlongY) - offsetAlongY)
+  ];
+};
+
 export function updateClippingPlanes(sceneProps: SceneLayerProps, displayProps: DisplayProps) {
   // Whenever the scene is translated/zoomed, update the clipping planes
-  const { x, y } = sceneProps.offset;
-  const worldExtents = {
-    x: sceneProps.zoom * (displayProps.resolution.x / 2),
-    y: sceneProps.zoom * (displayProps.resolution.y / 2)
-  };
+  clippingPlaneStore.value = rectClippingPlanes(sceneProps, { x: 0, y: 0 }, 0, {
+    x: displayProps.resolution.x / 2,
+    y: displayProps.resolution.y / 2
+  });
+}
 
-  clippingPlaneStore.value = [
-    new THREE.Plane(new THREE.Vector3(-1, 0, 0), worldExtents.x + x),
-    new THREE.Plane(new THREE.Vector3(1, 0, 0), worldExtents.x - x),
-    new THREE.Plane(new THREE.Vector3(0, 1, 0), worldExtents.y - y),
-    new THREE.Plane(new THREE.Vector3(0, -1, 0), worldExtents.y + y)
-  ];
+export function updateMapClippingPlanes(
+  sceneProps: SceneLayerProps,
+  mapProps: MapLayerProps,
+  mapSize: Size | null,
+  displayProps: DisplayProps
+) {
+  // Until the map image has loaded, fall back to the display bounds
+  if (!mapSize) {
+    mapClippingPlaneStore.value = rectClippingPlanes(sceneProps, { x: 0, y: 0 }, 0, {
+      x: displayProps.resolution.x / 2,
+      y: displayProps.resolution.y / 2
+    });
+    return;
+  }
+
+  mapClippingPlaneStore.value = rectClippingPlanes(sceneProps, mapProps.offset, (mapProps.rotation / 180.0) * Math.PI, {
+    x: (mapSize.width * mapProps.zoom) / 2,
+    y: (mapSize.height * mapProps.zoom) / 2
+  });
 }


### PR DESCRIPTION
Weather and light effects now stay within the bounds of the map, matching how fog behaves, instead of spilling onto the empty area around it.