### PR TITLE
Apply fog/drawing mask changes immediately when switching scenes"

### DIFF
--- a/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
+++ b/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
@@ -812,9 +812,9 @@
   };
 
   // Annotation mask strokes -> doc, debounced per layer
-  const annotationMaskTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  const pendingAnnotationCommits = new Map<string, { timer: ReturnType<typeof setTimeout>; sceneId: string }>();
 
-  const commitAnnotationMask = async (layerId: string) => {
+  const commitAnnotationMask = async (sceneId: string, layerId: string) => {
     if (!session.client || !stage?.annotations) return;
     if (stage.annotations.isDrawing()) return;
 
@@ -824,47 +824,79 @@
     try {
       const rle = await stage.annotations.toRLE();
       if (rle && rle.length > 0) {
-        session.client.write.setAnnotationMask(selectedSceneId, layerId, rle);
+        session.client.write.setAnnotationMask(sceneId, layerId, rle);
       }
     } finally {
       stageProps.annotations.activeLayer = originalActiveLayer;
     }
   };
 
+  // Like fog: pending commits land on the scene the stroke was drawn on, flushed
+  // on scene switch while the stage still holds that scene's layers
+  $effect(() => {
+    for (const [layerId, pending] of pendingAnnotationCommits) {
+      if (pending.sceneId !== selectedSceneId) {
+        pendingAnnotationCommits.delete(layerId);
+        clearTimeout(pending.timer);
+        commitAnnotationMask(pending.sceneId, layerId);
+      }
+    }
+  });
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onAnnotationUpdate = (layerId: string, _blob: Promise<Blob>) => {
-    const existing = annotationMaskTimers.get(layerId);
-    if (existing) clearTimeout(existing);
-    annotationMaskTimers.set(
-      layerId,
-      setTimeout(() => {
-        annotationMaskTimers.delete(layerId);
-        commitAnnotationMask(layerId);
+    const existing = pendingAnnotationCommits.get(layerId);
+    if (existing) clearTimeout(existing.timer);
+    const sceneId = selectedSceneId;
+    pendingAnnotationCommits.set(layerId, {
+      sceneId,
+      timer: setTimeout(() => {
+        pendingAnnotationCommits.delete(layerId);
+        if (selectedSceneId === sceneId) commitAnnotationMask(sceneId, layerId);
       }, 500)
-    );
+    });
   };
 
   // Fog of war -------------------------------------------------------------------
 
-  let fogCommitTimer: ReturnType<typeof setTimeout> | null = null;
+  let pendingFogCommit: { timer: ReturnType<typeof setTimeout>; sceneId: string } | null = null;
 
-  const commitFogMask = async () => {
+  const commitFogMask = async (sceneId: string) => {
     if (!session.client || !stage?.fogOfWar) return;
     if (stage.fogOfWar.isDrawing()) return; // next stroke end re-arms
     const rle = await stage.fogOfWar.toRLE();
     if (rle && !stage.fogOfWar.isDrawing()) {
-      session.client.write.setFogMask(selectedSceneId, rle);
+      session.client.write.setFogMask(sceneId, rle);
     }
   };
+
+  // A pending commit must land on the scene the stroke was drawn on. Flushing at
+  // switch time is safe: the fog canvas still shows that scene's mask until the
+  // new map texture loads and applyMasks repaints it.
+  const flushPendingFogCommit = () => {
+    if (!pendingFogCommit) return;
+    const { timer, sceneId } = pendingFogCommit;
+    pendingFogCommit = null;
+    clearTimeout(timer);
+    commitFogMask(sceneId);
+  };
+
+  $effect(() => {
+    if (pendingFogCommit && pendingFogCommit.sceneId !== selectedSceneId) flushPendingFogCommit();
+  });
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const onFogUpdate = (_blob: Promise<Blob>) => {
     trackChecklistItemLocal('fog-erase');
-    if (fogCommitTimer) clearTimeout(fogCommitTimer);
-    fogCommitTimer = setTimeout(() => {
-      fogCommitTimer = null;
-      commitFogMask();
-    }, 500);
+    if (pendingFogCommit) clearTimeout(pendingFogCommit.timer);
+    const sceneId = selectedSceneId;
+    pendingFogCommit = {
+      sceneId,
+      timer: setTimeout(() => {
+        pendingFogCommit = null;
+        if (selectedSceneId === sceneId) commitFogMask(sceneId);
+      }, 500)
+    };
   };
 
   // Measurements (broadcast only when editing the active scene) -------------------
@@ -1092,9 +1124,9 @@
     }
 
     return () => {
-      if (fogCommitTimer) clearTimeout(fogCommitTimer);
-      annotationMaskTimers.forEach((timer) => clearTimeout(timer));
-      annotationMaskTimers.clear();
+      if (pendingFogCommit) clearTimeout(pendingFogCommit.timer);
+      pendingAnnotationCommits.forEach((pending) => clearTimeout(pending.timer));
+      pendingAnnotationCommits.clear();
       dragClearTimers.forEach((timer) => clearTimeout(timer));
       dragClearTimers.clear();
       unbindPropertyUpdates();

--- a/apps/web/src/routes/(app)/[party]/play/+page@.svelte
+++ b/apps/web/src/routes/(app)/[party]/play/+page@.svelte
@@ -120,6 +120,12 @@
   });
 
   const sceneIsChanging = $derived(session.activeSceneId !== null && session.activeSceneId !== renderedSceneId);
+
+  // A pending fog commit belongs to the scene it was drawn on; flush it the
+  // moment the GM switches scenes, before the stage repaints
+  $effect(() => {
+    if (session.activeSceneId !== renderedSceneId) tools.flushPendingFogCommit();
+  });
   const gameIsPaused = $derived(session.isPaused || !session.activeSceneId);
   const stageClasses = $derived([
     'stage',

--- a/apps/web/src/routes/(app)/[party]/play/usePlayTools.svelte.ts
+++ b/apps/web/src/routes/(app)/[party]/play/usePlayTools.svelte.ts
@@ -89,7 +89,7 @@ export class PlayTools {
   #pendingPersistPosition: { x: number; y: number } | null = null;
   #persistButtonTimer: ReturnType<typeof setTimeout> | null = null;
   #resetLayerTimer: ReturnType<typeof setTimeout> | null = null;
-  #fogCommitTimer: ReturnType<typeof setTimeout> | null = null;
+  #pendingFogCommit: { timer: ReturnType<typeof setTimeout>; sceneId: string } | null = null;
   #expiryTicker: ReturnType<typeof setInterval>;
   #now = $state(Date.now());
   // Memoized base64 → bytes per layer so mask references stay stable across rebuilds
@@ -358,18 +358,34 @@ export class PlayTools {
   /** Stage callback: a fog stroke changed — commit the RLE to the doc, debounced. */
   onFogUpdate = () => {
     this.resetToNoneAfterDelay();
-    if (this.#fogCommitTimer) clearTimeout(this.#fogCommitTimer);
-    this.#fogCommitTimer = setTimeout(() => {
-      this.#fogCommitTimer = null;
-      this.#commitFog();
-    }, FOG_COMMIT_DEBOUNCE_MS);
+    const sceneId = this.#options.session.activeSceneId;
+    if (!sceneId) return;
+    if (this.#pendingFogCommit) clearTimeout(this.#pendingFogCommit.timer);
+    this.#pendingFogCommit = {
+      sceneId,
+      timer: setTimeout(() => {
+        this.#pendingFogCommit = null;
+        if (this.#options.session.activeSceneId === sceneId) this.#commitFog(sceneId);
+      }, FOG_COMMIT_DEBOUNCE_MS)
+    };
   };
 
-  async #commitFog() {
+  /**
+   * Commit a pending fog stroke to the scene it was drawn on. Called when the
+   * active scene changes, while the fog canvas still shows that scene's mask.
+   */
+  flushPendingFogCommit() {
+    if (!this.#pendingFogCommit) return;
+    const { timer, sceneId } = this.#pendingFogCommit;
+    this.#pendingFogCommit = null;
+    clearTimeout(timer);
+    this.#commitFog(sceneId);
+  }
+
+  async #commitFog(sceneId: string) {
     const { session, getStage } = this.#options;
     const stage = getStage();
-    const sceneId = session.activeSceneId;
-    if (!stage?.fogOfWar || !sceneId || !session.client) return;
+    if (!stage?.fogOfWar || !session.client) return;
     if (stage.fogOfWar.isDrawing()) return; // the next stroke end re-arms the commit
 
     try {
@@ -483,6 +499,6 @@ export class PlayTools {
     clearInterval(this.#expiryTicker);
     if (this.#resetLayerTimer) clearTimeout(this.#resetLayerTimer);
     if (this.#persistButtonTimer) clearTimeout(this.#persistButtonTimer);
-    if (this.#fogCommitTimer) clearTimeout(this.#fogCommitTimer);
+    if (this.#pendingFogCommit) clearTimeout(this.#pendingFogCommit.timer);
   }
 }


### PR DESCRIPTION
If you switched scenes after editing fog within 500ms, the fog change would apply to the newly switched scene rather than the original. The new login will apply that change immediately, rather than wait for more updates. This will prevent it from applying to the newly switched scene.