### PR TITLE
Scene zooms persist during scene edits

### DIFF
--- a/apps/web/src/lib/changelog/2026-06.md
+++ b/apps/web/src/lib/changelog/2026-06.md
@@ -6,7 +6,12 @@ The editor and playfield now share a live, Figma-style sync system. Edits — fo
 
 The editor now supports undo and redo with Ctrl + Z and Ctrl + Shift + Z (Cmd on Mac). Walk back fog strokes, drawings, marker moves, deletions, and scene setting changes. [#449](https://github.com/Siege-Perilous/tableslayer/pull/449)
 
+#### New weather and drawing effects
+
+Blizzard, Dust Storm, Embers and Fireflies added to weather effects. Entangle and web added to drawing effects. The grease effect was visually adjusted to look more like grease with a slight rainbow shimmer. [#451](https://github.com/Siege-Perilous/tableslayer/pull/451)
+
 #### Fixes
 
+- The brush for fog and drawing is now sized in grid units rather than a vague percentage value. [#452](https://github.com/Siege-Perilous/tableslayer/pull/452)
 - Scene links now use a stable address that doesn't change when scenes are reordered. Old links redirect automatically. [#448](https://github.com/Siege-Perilous/tableslayer/pull/448)
 - Weather and light effects now stay within the bounds of the map, matching how fog behaves, instead of spilling onto the empty area around it. [#450](https://github.com/Siege-Perilous/tableslayer/pull/450)

--- a/apps/web/src/lib/realtime/buildRenderProps.ts
+++ b/apps/web/src/lib/realtime/buildRenderProps.ts
@@ -17,6 +17,7 @@ export interface LocalView {
     offset?: { x: number; y: number };
     zoom?: number;
     rotation?: number;
+    autoFit?: boolean;
   };
   /** In-progress map alignment drag (committed to the doc on gesture end). */
   mapTransform?: {
@@ -57,6 +58,7 @@ export const buildRenderProps = (snapshot: SceneSnapshot, view: LocalView, bucke
   if (view.viewport?.offset) props.scene.offset = view.viewport.offset;
   if (view.viewport?.zoom !== undefined) props.scene.zoom = view.viewport.zoom;
   if (view.viewport?.rotation !== undefined) props.scene.rotation = view.viewport.rotation;
+  if (view.viewport?.autoFit !== undefined) props.scene.autoFit = view.viewport.autoFit;
 
   if (view.mapTransform?.offset) props.map.offset = view.mapTransform.offset;
   if (view.mapTransform?.zoom !== undefined) props.map.zoom = view.mapTransform.zoom;

--- a/apps/web/src/lib/utils/handleStageZoom.ts
+++ b/apps/web/src/lib/utils/handleStageZoom.ts
@@ -20,6 +20,9 @@ export const handleStageZoom = (e: WheelEvent, stageProps: StageProps) => {
     trackChecklistItem('scale-map');
   } else if (e.ctrlKey) {
     e.preventDefault();
+    // Manual zoom opts out of auto-fit so layout changes (pane resize, toolbar
+    // expand) don't snap the viewport back to the fitted zoom.
+    stageProps.scene.autoFit = false;
     const newSceneZoom = Math.max(minZoom, Math.min(stageProps.scene.zoom - scrollDelta, maxZoom));
     queuePropertyUpdate(stageProps, ['scene', 'zoom'], newSceneZoom, 'control');
   }

--- a/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
+++ b/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
@@ -232,9 +232,15 @@
             ? {
                 offset: { x: snapshot.settings.sceneOffsetX, y: snapshot.settings.sceneOffsetY },
                 rotation: snapshot.settings.sceneRotation,
-                zoom: 1
+                zoom: 1,
+                autoFit: true
               }
-            : { offset: prev.scene.offset, zoom: prev.scene.zoom, rotation: prev.scene.rotation },
+            : {
+                offset: prev.scene.offset,
+                zoom: prev.scene.zoom,
+                rotation: prev.scene.rotation,
+                autoFit: prev.scene.autoFit
+              },
           markerPositions: drags,
           fogTool: isSceneSwitch
             ? { size: clampFogBrush(getPreference('brushSizeGridUnits') || 2) }
@@ -560,7 +566,10 @@
   // Stage callbacks: every shared edit writes the doc; nothing here saves to the DB
   // ---------------------------------------------------------------------------
 
-  const handleSceneFit = () => stage.scene.fit();
+  const handleSceneFit = () => {
+    stageProps.scene.autoFit = true;
+    stage.scene.fit();
+  };
   const handleMapFill = () => stage.map.fit();
   const handleMapFit = () => stage.map.fit();
 
@@ -1015,6 +1024,7 @@
   }
 
   function onScenePan(dx: number, dy: number) {
+    stageProps.scene.autoFit = false;
     stageProps.scene.offset.x += dx;
     stageProps.scene.offset.y += dy;
   }
@@ -1024,6 +1034,7 @@
   }
 
   function onSceneZoom(zoom: number) {
+    stageProps.scene.autoFit = false;
     queuePropertyUpdate(stageProps, ['scene', 'zoom'], zoom, 'control');
   }
 
@@ -1163,7 +1174,7 @@
         saveCollapseState();
       }}
       onResize={() => {
-        if (stage) {
+        if (stage && stageProps.scene.autoFit) {
           stage.scene.fit();
         }
       }}
@@ -1327,7 +1338,7 @@
         saveCollapseState();
       }}
       onResize={() => {
-        if (stage) {
+        if (stage && stageProps.scene.autoFit) {
           stage.scene.fit();
         }
       }}


### PR DESCRIPTION
There was a regression in https://github.com/Siege-Perilous/tableslayer/pull/448 that caused the scene zoom to not persist after edits were made within the scene (after the edit, the scene would be rebuilt). It will now store that value locally.