### PR TITLE
Fix snap to grid for lights and markers

### DIFF
--- a/apps/web/src/lib/components/GameSession/LightManager.svelte
+++ b/apps/web/src/lib/components/GameSession/LightManager.svelte
@@ -26,6 +26,7 @@
   } from '@tableslayer/stage';
   import { IconTrash, IconArrowBack, IconFlame, IconLocationPin, IconCopy } from '@tabler/icons-svelte';
   import { queuePropertyUpdate, throttle } from '$lib/utils';
+  import { setPreference } from '$lib/utils/gameSessionPreferences';
   import { v4 as uuidv4 } from 'uuid';
 
   let {
@@ -178,6 +179,7 @@
       ]}
       onSelectedChange={(value) => {
         queuePropertyUpdate(stageProps, ['light', 'snapToGrid'], value === 'true', 'control');
+        setPreference('lightSnapToGrid', value === 'true');
       }}
     />
   </div>

--- a/apps/web/src/lib/components/GameSession/MarkerManager.svelte
+++ b/apps/web/src/lib/components/GameSession/MarkerManager.svelte
@@ -42,6 +42,7 @@
   import { useUploadFileMutation } from '$lib/queries';
   import type { Snippet } from 'svelte';
   import { queuePropertyUpdate, extractLocationFromUrl, throttle, trackChecklistItem } from '$lib/utils';
+  import { setPreference } from '$lib/utils/gameSessionPreferences';
   import { handleMutation } from '$lib/factories';
 
   let {
@@ -197,6 +198,7 @@
       ]}
       onSelectedChange={(value) => {
         queuePropertyUpdate(stageProps, ['marker', 'snapToGrid'], value === 'true', 'control');
+        setPreference('markerSnapToGrid', value === 'true');
       }}
     />
   </div>

--- a/apps/web/src/lib/components/GameSession/SceneSelector.svelte
+++ b/apps/web/src/lib/components/GameSession/SceneSelector.svelte
@@ -11,7 +11,18 @@
   import { devLog } from '$lib/utils/debug';
   import { extractDimensionsFromFilename } from '$lib/utils/gridDimensions';
   import { GridMode } from '@tableslayer/stage';
-  import { Button, ColorMode, FileInput, FormControl, Icon, IconButton, Input, Popover } from '@tableslayer/ui';
+  import {
+    Button,
+    ColorMode,
+    ConfirmActionButton,
+    FileInput,
+    FormControl,
+    Icon,
+    IconButton,
+    Input,
+    Popover,
+    Text
+  } from '@tableslayer/ui';
   import {
     IconCheck,
     IconChevronDown,
@@ -505,16 +516,20 @@
             >
               Change map image
             </button>
-            <button
-              class="scene__menuItem"
-              data-testid="sceneMenuDelete"
-              onclick={() => {
+            <ConfirmActionButton
+              actionButtonText="Confirm delete"
+              action={() => {
                 handleDeleteScene(scene.id);
                 contentProps.close();
               }}
             >
-              Delete scene
-            </button>
+              {#snippet trigger({ triggerProps })}
+                <button class="scene__menuItem" data-testid="sceneMenuDelete" {...triggerProps}>Delete scene</button>
+              {/snippet}
+              {#snippet actionMessage()}
+                <Text size="0.875rem" color="var(--fgDanger)">Delete this scene? This can not be undone.</Text>
+              {/snippet}
+            </ConfirmActionButton>
             <button
               class="scene__menuItem"
               data-testid="sceneMenuSetActive"

--- a/apps/web/src/lib/realtime/buildRenderProps.ts
+++ b/apps/web/src/lib/realtime/buildRenderProps.ts
@@ -26,6 +26,9 @@ export interface LocalView {
   };
   /** In-progress marker drags by id (committed to the doc on drop). */
   markerPositions?: Record<string, { x: number; y: number }>;
+  /** Snap-to-grid is a per-user preference, not a shared scene setting. */
+  marker?: { snapToGrid?: boolean };
+  light?: { snapToGrid?: boolean };
   /** Local tool configuration; brush size/line width are per-user preferences. */
   fogTool?: { type?: ToolType; size?: number; mode?: DrawMode };
   annotations?: {
@@ -69,6 +72,9 @@ export const buildRenderProps = (snapshot: SceneSnapshot, view: LocalView, bucke
       if (override) marker.position = override;
     }
   }
+
+  if (view.marker?.snapToGrid !== undefined) props.marker.snapToGrid = view.marker.snapToGrid;
+  if (view.light?.snapToGrid !== undefined) props.light.snapToGrid = view.light.snapToGrid;
 
   if (view.fogTool?.type !== undefined) props.fogOfWar.tool.type = view.fogTool.type;
   if (view.fogTool?.size !== undefined) props.fogOfWar.tool.size = view.fogTool.size;

--- a/apps/web/src/lib/utils/gameSessionPreferences.ts
+++ b/apps/web/src/lib/utils/gameSessionPreferences.ts
@@ -15,6 +15,8 @@ export interface GameSessionPreferences {
   brushSizeGridUnits?: number;
   annotationLineWidthGridUnits?: number;
   annotationSmoothing?: boolean;
+  markerSnapToGrid?: boolean;
+  lightSnapToGrid?: boolean;
   paneLayoutDesktop?: PaneConfig[];
   paneLayoutMobile?: PaneConfig[];
 }
@@ -47,6 +49,16 @@ export const PREFERENCE_CONFIGS: Record<keyof GameSessionPreferences, Preference
   annotationSmoothing: {
     cookieName: 'tableslayer:annotationSmoothing',
     defaultValue: true, // ON by default in editor
+    validate: (value): value is boolean => typeof value === 'boolean'
+  },
+  markerSnapToGrid: {
+    cookieName: 'tableslayer:markerSnapToGrid',
+    defaultValue: true, // ON by default
+    validate: (value): value is boolean => typeof value === 'boolean'
+  },
+  lightSnapToGrid: {
+    cookieName: 'tableslayer:lightSnapToGrid',
+    defaultValue: false, // OFF by default
     validate: (value): value is boolean => typeof value === 'boolean'
   },
   paneLayoutDesktop: {

--- a/apps/web/src/lib/utils/propertyUpdateBroadcaster.ts
+++ b/apps/web/src/lib/utils/propertyUpdateBroadcaster.ts
@@ -22,6 +22,8 @@ const LOCAL_ONLY_PREFIXES = [
   'annotations.activeLayer',
   'annotations.lineWidth',
   'annotations.smoothingEnabled',
+  'marker.snapToGrid', // per-user preference, stored in a cookie
+  'light.snapToGrid', // per-user preference, stored in a cookie
   'fogOfWar.tool', // brush size/mode/type are per-user tools
   'measurement', // measurement tool config is ephemeral
   'debug'

--- a/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
+++ b/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
@@ -177,6 +177,8 @@
     props.fogOfWar.tool.size = clampFogBrush(getPreference('brushSizeGridUnits') || 2);
     props.annotations.lineWidth = snapAnnotationBrush(getPreference('annotationLineWidthGridUnits') || 0.5);
     props.annotations.smoothingEnabled = getPreference('annotationSmoothing') ?? true;
+    props.marker.snapToGrid = getPreference('markerSnapToGrid') ?? true;
+    props.light.snapToGrid = getPreference('lightSnapToGrid') ?? false;
     return props;
   });
 
@@ -206,6 +208,8 @@
           props.fogOfWar.tool.size = clampFogBrush(getPreference('brushSizeGridUnits') || 2);
           props.annotations.lineWidth = snapAnnotationBrush(getPreference('annotationLineWidthGridUnits') || 0.5);
           props.annotations.smoothingEnabled = getPreference('annotationSmoothing') ?? true;
+          props.marker.snapToGrid = getPreference('markerSnapToGrid') ?? true;
+          props.light.snapToGrid = getPreference('lightSnapToGrid') ?? false;
           stageProps = props;
           activeControl = 'none';
           selectedMarkerId = undefined;
@@ -256,6 +260,12 @@
                 lineWidth: prev.annotations.lineWidth,
                 smoothingEnabled: prev.annotations.smoothingEnabled
               },
+          marker: isSceneSwitch
+            ? { snapToGrid: getPreference('markerSnapToGrid') ?? true }
+            : { snapToGrid: prev.marker.snapToGrid },
+          light: isSceneSwitch
+            ? { snapToGrid: getPreference('lightSnapToGrid') ?? false }
+            : { snapToGrid: prev.light.snapToGrid },
           measurement: isSceneSwitch
             ? undefined
             : {

--- a/apps/web/src/routes/api/scenes/createScene/+server.ts
+++ b/apps/web/src/routes/api/scenes/createScene/+server.ts
@@ -5,7 +5,10 @@ import { z } from 'zod';
 
 const validationSchema = z.object({
   partyId: z.string(),
-  sceneData: insertSceneSchema
+  // Scene order uses fractional indexing in the session doc (see orderBetween), so a
+  // duplicated/inserted scene can carry a non-integer order. Relax the schema's int
+  // constraint on this one field; SQLite's integer affinity stores the real value fine.
+  sceneData: insertSceneSchema.extend({ order: z.number().optional() })
 });
 
 export const POST = apiFactory(

--- a/apps/web/tests/e2e/scene.auth.test.ts
+++ b/apps/web/tests/e2e/scene.auth.test.ts
@@ -111,12 +111,10 @@ test.describe('Scene CRUD operations', () => {
     await expect(deleteMenuItem).toBeVisible({ timeout: 5000 });
     await deleteMenuItem.click({ force: true });
 
-    // Confirm deletion if confirmation dialog appears
+    // Deletion now requires confirmation via the ConfirmActionButton popover
     const confirmBtn = page.getByTestId('confirmActionButton');
-    if (await confirmBtn.isVisible({ timeout: 2000 }).catch(() => false)) {
-      await confirmBtn.click({ force: true });
-      console.log('[scene test] confirmed deletion');
-    }
+    await expect(confirmBtn).toBeVisible({ timeout: 5000 });
+    await confirmBtn.click({ force: true });
 
     // Wait for deletion to complete
     await page.waitForLoadState('networkidle');


### PR DESCRIPTION
Slight regression during the yjs state cleanup. We want the markers and lights to persist the snap to grid settings as a cookie.

While in here I also made it so that deleting scenes requires a confirm action.