### PR TITLE
Make drizzle connections more resiliant to embedded replica errors

### DIFF
--- a/apps/web/src/lib/db/app/index.ts
+++ b/apps/web/src/lib/db/app/index.ts
@@ -3,6 +3,7 @@ import { type Client, createClient } from '@libsql/client';
 import { config } from 'dotenv';
 import { drizzle } from 'drizzle-orm/libsql';
 import fs from 'fs';
+import { makeResilientClient } from './resilientClient';
 
 config({ path: '.env' });
 
@@ -103,4 +104,4 @@ await initializeDatabase();
 // Create a simple endpoint to check the database mode
 export const getDatabaseMode = () => databaseMode;
 
-export const db = drizzle(client!);
+export const db = drizzle(makeResilientClient(client!));

--- a/apps/web/src/lib/db/app/resilientClient.test.ts
+++ b/apps/web/src/lib/db/app/resilientClient.test.ts
@@ -1,0 +1,100 @@
+import type { Client } from '@libsql/client';
+import { describe, expect, it, vi } from 'vitest';
+import { isStreamError, makeResilientClient } from './resilientClient';
+
+const streamError = () =>
+  new Error('Hrana(Api("status=404 Not Found, body={\\"error\\":\\"stream not found: 2c4be4b6:a2a9\\"}"))');
+
+describe('isStreamError', () => {
+  it('matches each recoverable stream-error variant', () => {
+    for (const message of [
+      'stream not found: abc',
+      'STREAM_EXPIRED',
+      'stream has expired',
+      'HRANA_CLOSED',
+      'invalid baton'
+    ]) {
+      expect(isStreamError(new Error(message))).toBe(true);
+    }
+  });
+
+  it('walks the cause chain (Drizzle wraps the libsql error)', () => {
+    const wrapped = new Error('Failed query: delete from "session"', { cause: streamError() });
+    expect(isStreamError(wrapped)).toBe(true);
+  });
+
+  it('returns false for unrelated errors', () => {
+    expect(isStreamError(new Error('SQLITE_BUSY: database is locked'))).toBe(false);
+    expect(isStreamError(new Error('UNIQUE constraint failed'))).toBe(false);
+    expect(isStreamError(undefined)).toBe(false);
+  });
+
+  it('does not loop on a circular cause chain', () => {
+    const a = new Error('boom') as Error & { cause?: unknown };
+    a.cause = a;
+    expect(isStreamError(a)).toBe(false);
+  });
+});
+
+// Minimal fake client exposing the surface the proxy touches.
+const makeFakeClient = (execute: (...args: unknown[]) => Promise<unknown>) => {
+  const reconnect = vi.fn(async () => {});
+  return { execute: vi.fn(execute), batch: vi.fn(execute), reconnect } as unknown as Client & {
+    execute: ReturnType<typeof vi.fn>;
+    reconnect: ReturnType<typeof vi.fn>;
+  };
+};
+
+describe('makeResilientClient', () => {
+  it('reconnects once and retries when execute hits a stream error, then succeeds', async () => {
+    let calls = 0;
+    const fake = makeFakeClient(async () => {
+      calls += 1;
+      if (calls === 1) throw streamError();
+      return { rows: ['ok'] };
+    });
+
+    const client = makeResilientClient(fake);
+    const result = await client.execute('delete from "session" where id = ?');
+
+    expect(result).toEqual({ rows: ['ok'] });
+    expect(fake.execute).toHaveBeenCalledTimes(2);
+    expect(fake.reconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('rethrows a non-stream error without reconnecting', async () => {
+    const fake = makeFakeClient(async () => {
+      throw new Error('UNIQUE constraint failed');
+    });
+
+    const client = makeResilientClient(fake);
+    await expect(client.execute('insert ...')).rejects.toThrow('UNIQUE constraint failed');
+    expect(fake.reconnect).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the error after a single retry (no infinite loop)', async () => {
+    const fake = makeFakeClient(async () => {
+      throw streamError();
+    });
+
+    const client = makeResilientClient(fake);
+    await expect(client.execute('delete ...')).rejects.toThrow(/stream not found/);
+    expect(fake.execute).toHaveBeenCalledTimes(2);
+    expect(fake.reconnect).toHaveBeenCalledTimes(1);
+  });
+
+  it('single-flights the reconnect across concurrent failures', async () => {
+    let firstAttempts = 0;
+    const fake = makeFakeClient(async () => {
+      firstAttempts += 1;
+      if (firstAttempts <= 5) throw streamError(); // all 5 concurrent first-attempts fail
+      return { rows: [] };
+    });
+
+    const client = makeResilientClient(fake);
+    await Promise.all(Array.from({ length: 5 }, () => client.execute('delete ...')));
+
+    // 5 concurrent failing calls should trigger exactly one shared reconnect.
+    expect(fake.reconnect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/lib/db/app/resilientClient.ts
+++ b/apps/web/src/lib/db/app/resilientClient.ts
@@ -1,0 +1,63 @@
+import type { Client } from '@libsql/client';
+
+// libsql/Turso embedded-replica stream errors that an in-place reconnect() can recover from.
+// See spec/embedded-replica-stream-recovery.md for the full rationale (libsql#2083, #1856).
+const STREAM_ERRORS = /stream not found|stream (has )?expired|STREAM_EXPIRED|HRANA_CLOSED|invalid baton/i;
+
+// Drizzle wraps the libsql error in DrizzleQueryError, so walk the whole `cause` chain.
+export const isStreamError = (error: unknown): boolean => {
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  while (current != null && !seen.has(current)) {
+    seen.add(current);
+    const message =
+      typeof current === 'object' && 'message' in current
+        ? String((current as { message: unknown }).message)
+        : String(current);
+    if (STREAM_ERRORS.test(message)) return true;
+    current = typeof current === 'object' && 'cause' in current ? (current as { cause: unknown }).cause : undefined;
+  }
+  return false;
+};
+
+// `reconnect()` exists on the concrete client (sqlite3/http/ws) but is not on the exported Client type.
+type Reconnectable = { reconnect: () => Promise<void> };
+
+// Wraps a libsql client so that a dropped Hrana stream (e.g. after the primary restarts/upgrades)
+// self-heals: on a stream error, reconnect() the client in place and retry the statement once.
+// Only `execute`/`batch` are retried — transactions run through `tx.execute()` (drizzle) and are
+// deliberately left to surface, since a mid-transaction statement cannot be safely replayed.
+export const makeResilientClient = (client: Client): Client => {
+  let reconnecting: Promise<void> | null = null;
+
+  // Single-flight: concurrent failures share one reconnect rather than each recreating the handle.
+  const recover = (): Promise<void> =>
+    (reconnecting ??= (client as unknown as Reconnectable).reconnect().finally(() => {
+      reconnecting = null;
+    }));
+
+  return new Proxy(client, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value !== 'function') return value;
+
+      // Bind every method to the real client so private-field access works through the Proxy.
+      const method = value as (...args: unknown[]) => unknown;
+      if (prop !== 'execute' && prop !== 'batch') {
+        return (...args: unknown[]) => method.apply(target, args);
+      }
+
+      const runnable = method as (...args: unknown[]) => Promise<unknown>;
+      return async (...args: unknown[]): Promise<unknown> => {
+        try {
+          return await runnable.apply(target, args);
+        } catch (error) {
+          if (!isStreamError(error)) throw error;
+          console.warn('⚠️ libsql stream error; reconnecting client and retrying once', error);
+          await recover();
+          return await runnable.apply(target, args); // retry once; if it fails again, surface it
+        }
+      };
+    }
+  });
+};


### PR DESCRIPTION
Last night one of the embedded replicas in production ran into connection issues. After doing a bit of research it sounds like this can be common with embedded turso replicas. The suggestion was to add a reconnect method if the connection fails, which should "self-heal" the issue.