### PR TITLE
Allow more errors to properly hit Sentry

### DIFF
--- a/apps/web/src/lib/errors.ts
+++ b/apps/web/src/lib/errors.ts
@@ -1,0 +1,10 @@
+// Base class for expected, user-facing errors. apiFactory returns these as 400s and does NOT report
+// them to Sentry (unlike unexpected/infrastructure errors). See src/lib/factories/apiFactory.ts.
+// Lives outside $lib/server so apiFactory (re-exported from the client-reachable $lib/factories
+// barrel) can reference it without pulling a $lib/server module into the browser bundle.
+export class AppError extends Error {
+  constructor(message: string) {
+    super(message);
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/apps/web/src/lib/factories/apiFactory.test.ts
+++ b/apps/web/src/lib/factories/apiFactory.test.ts
@@ -1,0 +1,73 @@
+import { SlugConflictError } from '$lib/server/errors';
+import * as Sentry from '@sentry/sveltekit';
+import type { RequestEvent } from '@sveltejs/kit';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { apiFactory } from './apiFactory';
+
+vi.mock('@sentry/sveltekit', () => ({ captureException: vi.fn() }));
+
+const captureException = vi.mocked(Sentry.captureException);
+
+// Build a handler whose validated-body handler throws (or returns) the given value, then invoke it.
+const invoke = async (thrownOrResult: unknown, { throws = true, body = {} } = {}) => {
+  const handler = apiFactory(
+    async () => {
+      if (throws) throw thrownOrResult;
+      return thrownOrResult;
+    },
+    { validationSchema: z.object({ name: z.string() }).partial() }
+  );
+  const event = { request: { json: async () => body } } as unknown as RequestEvent;
+  const response = await handler(event);
+  return { status: response.status, json: await response.json() };
+};
+
+describe('apiFactory error classification', () => {
+  beforeEach(() => captureException.mockClear());
+
+  it('returns the message as a 400 for the plain Error idiom, without reporting to Sentry', async () => {
+    const { status, json } = await invoke(new Error('Scene not found'));
+    expect(status).toBe(400);
+    expect(json.message).toBe('Scene not found');
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('treats AppError subclasses as expected 400s, without Sentry', async () => {
+    const { status } = await invoke(new SlugConflictError('slug taken'));
+    expect(status).toBe(400);
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('reports typed Error subclasses (e.g. DB driver errors) as 500 + Sentry', async () => {
+    class DrizzleQueryError extends Error {}
+    const { status, json } = await invoke(new DrizzleQueryError('stream not found: abc'));
+    expect(status).toBe(500);
+    expect(json.message).not.toContain('stream not found'); // generic message, detail only in Sentry
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports non-Error throws as 500 + Sentry', async () => {
+    const { status } = await invoke('some string blew up');
+    expect(status).toBe(500);
+    expect(captureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles validation errors as 400 without Sentry', async () => {
+    const { status } = await invoke(null, { throws: false, body: { name: 123 } });
+    expect(status).toBe(400);
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('maps the Unauthorized idiom to 401 without Sentry', async () => {
+    const { status } = await invoke(new Error('Unauthorized'));
+    expect(status).toBe(401);
+    expect(captureException).not.toHaveBeenCalled();
+  });
+
+  it('returns handler results as 200 json', async () => {
+    const { status, json } = await invoke({ ok: true }, { throws: false });
+    expect(status).toBe(200);
+    expect(json).toEqual({ ok: true });
+  });
+});

--- a/apps/web/src/lib/factories/apiFactory.ts
+++ b/apps/web/src/lib/factories/apiFactory.ts
@@ -1,3 +1,5 @@
+import { AppError } from '$lib/server/errors';
+import * as Sentry from '@sentry/sveltekit';
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { z } from 'zod';
 
@@ -56,8 +58,9 @@ export function apiFactory<BodyType>(
         );
       }
 
-      // This covers custom errors set in $lib/server/errors
-      if (err instanceof Error) {
+      // Expected, user-facing errors: AppError subclasses and the plain `new Error('message')`
+      // idiom used throughout handlers. These are returned as 400s and NOT reported to Sentry.
+      if (err instanceof AppError || (err instanceof Error && err.constructor === Error)) {
         return json(
           {
             success: false,
@@ -68,7 +71,9 @@ export function apiFactory<BodyType>(
         );
       }
 
-      // Handle unexpected errors
+      // Anything else is unexpected — a typed Error subclass (e.g. DB/driver errors like
+      // DrizzleQueryError, or a code bug like TypeError) or a non-Error throw. Surface it to Sentry.
+      Sentry.captureException(err);
       return json(
         {
           success: false,

--- a/apps/web/src/lib/factories/apiFactory.ts
+++ b/apps/web/src/lib/factories/apiFactory.ts
@@ -1,4 +1,4 @@
-import { AppError } from '$lib/server/errors';
+import { AppError } from '$lib/errors';
 import * as Sentry from '@sentry/sveltekit';
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { z } from 'zod';

--- a/apps/web/src/lib/server/errors/index.ts
+++ b/apps/web/src/lib/server/errors/index.ts
@@ -1,11 +1,7 @@
-// Base class for expected, user-facing errors. apiFactory returns these as 400s and does NOT
-// report them to Sentry (unlike unexpected/infrastructure errors). See src/lib/factories/apiFactory.ts.
-export class AppError extends Error {
-  constructor(message: string) {
-    super(message);
-    Object.setPrototypeOf(this, new.target.prototype);
-  }
-}
+import { AppError } from '$lib/errors';
+
+// AppError is re-exported so existing `$lib/server/errors` / `$lib/server` imports keep working.
+export { AppError };
 
 export class SlugConflictError extends AppError {
   name = 'SlugConflictError';

--- a/apps/web/src/lib/server/errors/index.ts
+++ b/apps/web/src/lib/server/errors/index.ts
@@ -1,4 +1,13 @@
-export class SlugConflictError extends Error {
+// Base class for expected, user-facing errors. apiFactory returns these as 400s and does NOT
+// report them to Sentry (unlike unexpected/infrastructure errors). See src/lib/factories/apiFactory.ts.
+export class AppError extends Error {
+  constructor(message: string) {
+    super(message);
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}
+
+export class SlugConflictError extends AppError {
   name = 'SlugConflictError';
 
   constructor(message: string) {
@@ -7,7 +16,7 @@ export class SlugConflictError extends Error {
   }
 }
 
-export class UserAlreadyInvitedError extends Error {
+export class UserAlreadyInvitedError extends AppError {
   name = 'UserAlreadyInvitedError';
 
   constructor(message: string) {
@@ -16,7 +25,7 @@ export class UserAlreadyInvitedError extends Error {
   }
 }
 
-export class UserAlreadyInPartyError extends Error {
+export class UserAlreadyInPartyError extends AppError {
   name = 'UserAlreadyInPartyError';
 
   constructor(message: string) {
@@ -25,7 +34,7 @@ export class UserAlreadyInPartyError extends Error {
   }
 }
 
-export class UserIsLastAdminInParty extends Error {
+export class UserIsLastAdminInParty extends AppError {
   name = 'UserIsLastAdminInParty';
 
   constructor(message: string) {
@@ -34,7 +43,7 @@ export class UserIsLastAdminInParty extends Error {
   }
 }
 
-export class EmailAlreadyInUseError extends Error {
+export class EmailAlreadyInUseError extends AppError {
   name = 'EmailAlreadyInUseError';
 
   constructor(message: string) {


### PR DESCRIPTION
Previously errors would fire, but not hit sentry because they'd get swallowed. This makes a generic wrapper for App Errors so that the ones we're not worried about won't hit sentry, but other 500s will.