### PR TITLE
Performance adjustment for weather / post

### DIFF
--- a/packages/stage/src/lib/components/Stage/components/Scene/Scene.svelte
+++ b/packages/stage/src/lib/components/Stage/components/Scene/Scene.svelte
@@ -28,6 +28,7 @@
   import { getGridCellSize as getGridCellSizeHelper } from '../../helpers/grid';
   import { SceneLayer, SceneLayerOrder, SceneLoadingState } from './types';
   import type { AnnotationExports } from '../AnnotationLayer/types';
+  import type { PostProcessingProps } from './types';
   import AnnotationLayer from '../AnnotationLayer/AnnotationLayer.svelte';
   import CursorLayer from '../CursorLayer/CursorLayer.svelte';
   import type { CursorData } from '../CursorLayer/types';
@@ -104,6 +105,15 @@
   const intersectionPoint = new THREE.Vector3();
 
   let composer = new EffectComposer(renderer);
+
+  // Effects with zero-strength settings contribute nothing visible, so treat
+  // them as disabled; this lets the render loop bypass the composer entirely
+  const getActiveEffects = (pp: PostProcessingProps) => ({
+    bloom: pp.bloom.enabled && pp.bloom.intensity > 0,
+    chromaticAberration: pp.chromaticAberration.enabled && pp.chromaticAberration.offset !== 0,
+    vignette: pp.vignette.enabled && pp.vignette.darkness > 0,
+    lut: pp.lut.enabled && pp.lut.url !== null
+  });
 
   onMount(() => {
     let before = autoRender.current;
@@ -205,8 +215,10 @@
         const renderPass = new RenderPass(scene, $camera);
         composer.addPass(renderPass);
 
+        const activeEffects = getActiveEffects(postProcessing);
+
         if (postProcessing.enabled) {
-          if (postProcessing.bloom.enabled) {
+          if (activeEffects.bloom) {
             const bloomEffect = new BloomEffect({
               intensity: postProcessing.bloom.intensity,
               mipmapBlur: postProcessing.bloom.mipmapBlur,
@@ -218,7 +230,7 @@
             effects.push(bloomEffect);
           }
 
-          if (postProcessing.chromaticAberration.enabled) {
+          if (activeEffects.chromaticAberration) {
             const chromaticAberrationEffect = new ChromaticAberrationEffect({
               offset: new THREE.Vector2(postProcessing.chromaticAberration.offset),
               radialModulation: true,
@@ -227,7 +239,7 @@
             effects.push(chromaticAberrationEffect);
           }
 
-          if (postProcessing.vignette.enabled) {
+          if (activeEffects.vignette) {
             const vignetteEffect = new VignetteEffect({
               offset: postProcessing.vignette.offset,
               darkness: postProcessing.vignette.darkness,
@@ -236,7 +248,7 @@
             effects.push(vignetteEffect);
           }
 
-          if (postProcessing.lut.enabled && postProcessing.lut.url !== null) {
+          if (activeEffects.lut) {
             const lutEffect = new LUT3DEffect(new THREE.Data3DTexture(), {
               blendFunction: BlendFunction.SET
             });
@@ -285,7 +297,8 @@
   const hasActiveEffects = $derived(() => {
     const pp = props.postProcessing;
     if (!pp.enabled) return false;
-    return pp.bloom.enabled || pp.chromaticAberration.enabled || pp.vignette.enabled || pp.lut.enabled;
+    const activeEffects = getActiveEffects(pp);
+    return activeEffects.bloom || activeEffects.chromaticAberration || activeEffects.vignette || activeEffects.lut;
   });
 
   // Custom render task

--- a/packages/stage/src/lib/components/Stage/components/Stage/Stage.svelte
+++ b/packages/stage/src/lib/components/Stage/components/Stage/Stage.svelte
@@ -15,12 +15,16 @@
    * This fixes Chrome/Mac performance issues by:
    * - Requesting high-performance GPU mode (critical for macOS)
    * - Disabling unnecessary features like stencil buffer
+   *
+   * MSAA (antialias) is off: the scene is entirely textured quads whose edges
+   * are anti-aliased in their textures/shaders, and the post-processing path
+   * renders through non-MSAA targets anyway, so MSAA only costs bandwidth.
    */
   const createRenderer = (canvas: HTMLCanvasElement) => {
     return new THREE.WebGLRenderer({
       canvas,
       powerPreference: 'high-performance',
-      antialias: true,
+      antialias: false,
       alpha: false,
       stencil: false,
       depth: true

--- a/packages/stage/src/lib/components/Stage/components/WeatherLayer/WeatherLayer.svelte
+++ b/packages/stage/src/lib/components/Stage/components/WeatherLayer/WeatherLayer.svelte
@@ -132,6 +132,7 @@
   // Render particle scene directly to render target (bypasses unnecessary EffectComposer overhead)
   useTask(
     () => {
+      if (props.weather.type === WeatherType.None) return;
       if (!particleScene || !particleCamera || !size) return;
 
       particleScene.visible = true;
@@ -140,7 +141,6 @@
       renderer.render(particleScene, particleCamera);
       renderer.setRenderTarget(null);
       particleScene.visible = false;
-      quadMaterial.needsUpdate = true;
     },
     { stage: renderStage }
   );

--- a/packages/stage/src/lib/components/Stage/shaders/Fog.frag
+++ b/packages/stage/src/lib/components/Stage/shaders/Fog.frag
@@ -125,6 +125,14 @@ void main() {
     }
   }
 
+  // Fully revealed pixels far from any fog edge produce zero alpha, so skip
+  // the noise and feathering work entirely. The widest mip level is an average
+  // of the whole surrounding neighborhood; if it is ~0 here, every narrower
+  // mip and the base mask are ~0 too, making all mask() terms below zero.
+  if (textureLod(uMaskTexture, vUv, float(uEdgeMaxMipMapLevel)).a < 0.004) {
+    discard;
+  }
+
   // Sample at multiple levels of detail to get a nice feathered edge
   vec2 texSize = vec2(textureSize(uMaskTexture, 0));
 


### PR DESCRIPTION
This PR adjusts the default rendering of the Stage component to be more friendly towards less powerful computers.

- Turned off antialias, which wasn't really being used, but costing perf.
- Makes sure weather doesn't do render passes if not used.
- Makes sure post processing doesn't run the LUTs when the values are 0