### PR TITLE
Fix double popup test flakiness

### DIFF
--- a/apps/web/src/lib/components/GameSession/SceneSelector.svelte
+++ b/apps/web/src/lib/components/GameSession/SceneSelector.svelte
@@ -459,10 +459,7 @@
         <Popover
           triggerClass="scene__popoverBtn"
           triggerTestId="scenePopoverButton"
-          isOpen={openScenePopover === scene.id}
-          onIsOpenChange={(open) => {
-            if (!open) openScenePopover = null;
-          }}
+          bind:isOpen={() => openScenePopover === scene.id, (open) => (openScenePopover = open ? scene.id : null)}
           positioning={{ placement: 'bottom-end' }}
           portal="#scenes"
         >

--- a/apps/web/tests/e2e/scene.auth.test.ts
+++ b/apps/web/tests/e2e/scene.auth.test.ts
@@ -94,6 +94,9 @@ test.describe('Scene CRUD operations', () => {
     await expect(setActiveMenuItem).toBeVisible({ timeout: 5000 });
     await setActiveMenuItem.click({ force: true });
 
+    // Wait for the popover to close so the next menu open can't race it
+    await expect(setActiveMenuItem).not.toBeVisible({ timeout: 5000 });
+
     // Wait for the active scene indicator to appear
     await expect(page.getByTestId('sceneActiveIcon')).toBeVisible({ timeout: 10000 });
     await expect(page.getByTestId('sceneActiveIcon')).toContainText('Active on table', { timeout: 5000 });


### PR DESCRIPTION
There is a condition where two popups in the scene menu can be open at once, which causes the E2E tests to be flakey. This makes sure that one closes before the other opens.