### PR TITLE
Better mobile menus, fog room tutorial

### DIFF
--- a/apps/web/src/lib/changelog/2026-07.md
+++ b/apps/web/src/lib/changelog/2026-07.md
@@ -19,3 +19,7 @@ Table Slayer now adapts its rendering quality to your hardware. A new performanc
 </video>
 
 A new fog room tool (P) lets you outline rooms of fog point by point, perfect for prepping a dungeon ahead of a session. Click to place each corner, then press Enter, double-click, or click the first point to complete the room. Committed rooms are immune to the eraser, so revealing a hallway can't accidentally bleed into the next chamber. Check the shortcuts' helper in the editor for usage. [#471](https://github.com/Siege-Perilous/tableslayer/pull/471)
+
+#### Fixes
+
+- On mobile, the scene toolbar now collapses setup tools into a "..." menu so the fog, measurement, and play tools stay visible, and only one tool can show as active at a time. [#475](https://github.com/Siege-Perilous/tableslayer/pull/475)

--- a/apps/web/src/lib/components/Checklist/Checklist.svelte
+++ b/apps/web/src/lib/components/Checklist/Checklist.svelte
@@ -30,8 +30,6 @@
     }
   });
 
-  const completedCount = $derived(checklistItems.filter((item) => completedItems.includes(item.id)).length);
-
   const handleToggleExpand = (itemId: ChecklistItemId) => {
     expandedItemId = expandedItemId === itemId ? null : itemId;
   };
@@ -45,9 +43,6 @@
   <div class="checklist__header">
     <div class="checklist__headerContent">
       <h3 class="checklist__title">Learn Table Slayer in 5 minutes</h3>
-      <span class="checklist__progress" data-testid="checklistProgress">
-        {completedCount} / {checklistItems.length}
-      </span>
     </div>
     <button
       type="button"
@@ -103,14 +98,6 @@
     font-size: 1rem;
     font-weight: 600;
     margin: 0;
-  }
-
-  .checklist__progress {
-    font-size: 0.75rem;
-    color: var(--fgMuted);
-    background: var(--contrastLow);
-    padding: 0.125rem 0.5rem;
-    border-radius: var(--radius-2);
   }
 
   .checklist__closeButton {

--- a/apps/web/src/lib/components/Checklist/checklistItems.ts
+++ b/apps/web/src/lib/components/Checklist/checklistItems.ts
@@ -6,6 +6,7 @@ import {
   FogEraseInstructions,
   FogOpacityInstructions,
   FogResetInstructions,
+  FogRoomInstructions,
   LaunchPlayfieldInstructions,
   MapDefinedGridInstructions,
   MarkerVisibilityInstructions,
@@ -25,6 +26,7 @@ export type ChecklistItemId =
   | 'fog-opacity'
   | 'fog-erase'
   | 'fog-reset'
+  | 'fog-room'
   | 'weather'
   | 'measurement'
   | 'spell-effect'
@@ -69,6 +71,11 @@ export const checklistItems: ChecklistItem[] = [
     id: 'fog-reset',
     title: 'Reset the fog of war',
     instructions: FogResetInstructions
+  },
+  {
+    id: 'fog-room',
+    title: 'Create a fog room',
+    instructions: FogRoomInstructions
   },
   {
     id: 'weather',

--- a/apps/web/src/lib/components/Checklist/instructions/FogRoomInstructions.svelte
+++ b/apps/web/src/lib/components/Checklist/instructions/FogRoomInstructions.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import { Code, TextHighlight } from '@tableslayer/ui';
+  import { IconPolygon } from '@tabler/icons-svelte';
+</script>
+
+<p class="checklist__instructions">
+  Press <Code code="P" /> or pick <TextHighlight text="Fog room" icon={IconPolygon} /> from the fog tool menu, then click
+  around the map to outline a room. Press <Code code="Enter" /> to commit the outline. Right-click a room to reveal or hide
+  it, making it easy to uncover rooms as your players explore.
+</p>

--- a/apps/web/src/lib/components/Checklist/instructions/index.ts
+++ b/apps/web/src/lib/components/Checklist/instructions/index.ts
@@ -4,6 +4,7 @@ export { default as ChangeSceneInstructions } from './ChangeSceneInstructions.sv
 export { default as FogEraseInstructions } from './FogEraseInstructions.svelte';
 export { default as FogOpacityInstructions } from './FogOpacityInstructions.svelte';
 export { default as FogResetInstructions } from './FogResetInstructions.svelte';
+export { default as FogRoomInstructions } from './FogRoomInstructions.svelte';
 export { default as LaunchPlayfieldInstructions } from './LaunchPlayfieldInstructions.svelte';
 export { default as MapDefinedGridInstructions } from './MapDefinedGridInstructions.svelte';
 export { default as MarkerVisibilityInstructions } from './MarkerVisibilityInstructions.svelte';

--- a/apps/web/src/lib/components/GameSession/Hints.svelte
+++ b/apps/web/src/lib/components/GameSession/Hints.svelte
@@ -3,19 +3,29 @@
   let { stageProps }: { stageProps: StageProps } = $props();
   const activeLayer = $derived(stageProps.activeLayer);
   const isPolygonFogTool = $derived(stageProps.fogOfWar.tool.type === ToolType.Polygon);
+  const isTouch = typeof window !== 'undefined' && window.matchMedia('(pointer: coarse)').matches;
 </script>
 
 <div class="hints">
   {#if activeLayer === 1}
     {#if isPolygonFogTool}
-      Click to outline a fog room. <span>Enter</span>
-      completes it,
-      <span>Esc</span>
-      cancels.
-      <span>Right-click</span>
-      toggles a room,
-      <span>Delete</span>
-      while hovering removes it.
+      {#if isTouch}
+        Tap to outline a fog room. <span>Double-tap</span>
+        completes it.
+        <span>Double-tap</span>
+        a room to toggle it,
+        <span>press and hold</span>
+        to remove it.
+      {:else}
+        Click to outline a fog room. <span>Enter</span>
+        completes it,
+        <span>Esc</span>
+        cancels.
+        <span>Right-click</span>
+        toggles a room,
+        <span>Delete</span>
+        while hovering removes it.
+      {/if}
     {:else}
       Click and drag to reveal the fog. <span>F</span>
       to clear,
@@ -60,5 +70,17 @@
     padding: 0 4px;
     display: inline-block;
     color: var(--fg);
+  }
+
+  /* On narrow stages the hint wraps, so anchor it to the bottom away from the toolbar */
+  @container stageWrapper (max-width: 768px) {
+    .hints {
+      white-space: normal;
+      text-wrap: balance;
+      width: 100%;
+      text-align: center;
+      top: auto;
+      bottom: 3.5rem;
+    }
   }
 </style>

--- a/apps/web/src/lib/components/GameSession/SceneControls.svelte
+++ b/apps/web/src/lib/components/GameSession/SceneControls.svelte
@@ -16,6 +16,7 @@
     IconScreenShareOff,
     IconBorderSides,
     IconAdjustmentsHorizontal,
+    IconDots,
     IconPokerChip,
     IconPencil,
     IconPolygon,
@@ -52,10 +53,10 @@
     handleMapFit,
     errors = undefined,
     client,
-    keyboardPopoverId = null,
+    isCompact = false,
     onFogClear
   }: {
-    handleSelectActiveControl: (control: string) => string | null;
+    handleSelectActiveControl: (control: string, opts?: { toggle?: boolean }) => void;
     activeControl: string;
     stageProps: StageProps;
     party: SelectParty & Thumb;
@@ -67,7 +68,7 @@
     errors?: ZodIssue[] | undefined;
     stage: StageExports;
     client: SessionDocClient | null;
-    keyboardPopoverId?: string | null;
+    isCompact?: boolean;
     onFogClear?: () => void;
   } = $props();
 
@@ -130,6 +131,16 @@
       tooltip: "Open or pause the player's view",
       mapLayer: MapLayerType.None
     }
+  ];
+
+  // Play stays visible on compact toolbars; the rest collapse into the overflow menu
+  const popoverControls = sceneControlArray.filter((scene) => scene.id !== 'play');
+  const playControl = sceneControlArray.find((scene) => scene.id === 'play')!;
+
+  const drawingOverflowItems = [
+    { id: 'marker', icon: IconPokerChip, text: 'Marker', testId: 'markerToolButton' },
+    { id: 'annotation', icon: IconPencil, text: 'Draw', testId: undefined },
+    { id: 'light', icon: IconFlame, text: 'Light', testId: 'lightToolButton' }
   ];
 
   const eraseOptions = [
@@ -208,44 +219,101 @@
 
   const handleSelectedFogTool = (selected: string) => {
     const selectedOption = eraseOptions.find((option) => option.value === selected)!;
-    activeControl = 'erase';
-    queuePropertyUpdate(stageProps, ['activeLayer'], MapLayerType.FogOfWar, 'control');
+    handleSelectActiveControl('erase', { toggle: false });
     queuePropertyUpdate(stageProps, ['fogOfWar', 'tool', 'type'], selectedOption.toolType, 'control');
     queuePropertyUpdate(stageProps, ['fogOfWar', 'tool', 'mode'], selectedOption.drawMode, 'control');
   };
 
-  // Track which popover is currently open
-  let openPopoverId = $state<string | null>(null);
+  // activeControl (owned by the page) is the single source of truth: button
+  // highlights and popover visibility all derive from it
+  const handleToolPopoverChange = (id: string) => (open: boolean) => {
+    if (open !== (activeControl === id)) handleSelectActiveControl(id);
+  };
 
-  // React to keyboard-triggered popover changes
-  $effect(() => {
-    if (keyboardPopoverId !== undefined) {
-      openPopoverId = keyboardPopoverId;
-    }
-  });
+  // Overflow menu: overflowListOpen only tracks whether the list view is
+  // showing; an active popover tool keeps the popover open in controls view
+  let overflowListOpen = $state(false);
+  const overflowToolActive = $derived(popoverControls.some((scene) => scene.id === activeControl));
+  const overflowAnyActive = $derived(
+    overflowToolActive || drawingOverflowItems.some((item) => item.id === activeControl)
+  );
 
-  // Also react to activeControl changes to close popovers when tools are activated
-  $effect(() => {
-    if (['erase', 'marker', 'light', 'annotation', 'measurement'].includes(activeControl)) {
-      openPopoverId = null;
-    }
-  });
-
-  // Handle popover state changes (from trigger click, outside click, etc.)
-  const handlePopoverOpenChange = (sceneId: string) => (open: boolean) => {
+  const handleOverflowOpenChange = (open: boolean) => {
     if (open) {
-      openPopoverId = sceneId;
-      activeControl = sceneId;
+      overflowListOpen = true;
     } else {
-      if (openPopoverId === sceneId) {
-        openPopoverId = null;
-      }
-      if (activeControl === sceneId) {
-        activeControl = 'none';
-      }
+      overflowListOpen = false;
+      if (overflowToolActive) handleSelectActiveControl(activeControl);
+    }
+  };
+
+  // Popover tools reopen on the next task: the popover must close and remount
+  // so floating-ui measures the controls view (it only positions on open), and
+  // the reopen must happen after the click event so the popover's global
+  // outside-click handler doesn't see the detached list item and self-close
+  const handleOverflowItemSelect = (id: string) => {
+    overflowListOpen = false;
+    const isPopoverTool = popoverControls.some((scene) => scene.id === id);
+    if (isPopoverTool && activeControl !== id) {
+      setTimeout(() => handleSelectActiveControl(id), 0);
+    } else {
+      handleSelectActiveControl(id);
     }
   };
 </script>
+
+{#snippet toolControls(controlId: string)}
+  {#if controlId === 'grid'}
+    <GridControls
+      {stageProps}
+      {handleSelectActiveControl}
+      {activeControl}
+      {party}
+      {gameSession}
+      {stage}
+      {selectedScene}
+      {activeSceneId}
+      {handleMapFill}
+      {handleMapFit}
+      {errors}
+    />
+  {:else if controlId === 'fog'}
+    <FogControls {stage} {stageProps} {onFogClear} />
+  {:else if controlId === 'map'}
+    <MapControls
+      {stage}
+      {stageProps}
+      {handleSelectActiveControl}
+      {activeControl}
+      {party}
+      {selectedScene}
+      {activeSceneId}
+      {handleMapFill}
+      {handleMapFit}
+      {errors}
+      {client}
+    />
+  {:else if controlId === 'weather'}
+    <WeatherControls {stageProps} {errors} />
+  {:else if controlId === 'edge'}
+    <EdgeControls {stageProps} {errors} {party} />
+  {:else if controlId === 'effects'}
+    <EffectsControls {stageProps} {errors} {party} />
+  {/if}
+{/snippet}
+
+{#snippet overflowItem(id: string, ItemIcon: typeof IconMap, text: string, testId: string | undefined)}
+  <button
+    data-testid={testId}
+    class="sceneControls__layer sceneControls__layer--overflow {activeControl === id
+      ? 'sceneControls__layer--isActive'
+      : ''}"
+    onclick={() => handleOverflowItemSelect(id)}
+  >
+    <Icon Icon={ItemIcon} size="1.5rem" />
+    <span class="sceneControls__overflowLabel">{text}</span>
+  </button>
+{/snippet}
 
 <ColorMode mode="dark">
   <div class="sceneControls">
@@ -253,12 +321,8 @@
       <ToolTip positioning={{ placement: 'bottom' }} openDelay={500} closeOnPointerDown disableHoverableContent>
         {#snippet children()}
           <button
-            class="sceneControls__layer {stageProps.activeLayer === MapLayerType.FogOfWar &&
-              'sceneControls__layer--isActive'}"
-            onclick={() => {
-              const newPopoverId = handleSelectActiveControl('erase');
-              openPopoverId = newPopoverId;
-            }}
+            class="sceneControls__layer {activeControl === 'erase' ? 'sceneControls__layer--isActive' : ''}"
+            onclick={() => handleSelectActiveControl('erase')}
           >
             <Icon Icon={selectedFogTool.icon} size="1.5rem" />
           </button>
@@ -286,12 +350,8 @@
         <ToolTip positioning={{ placement: 'bottom' }} openDelay={500} closeOnPointerDown disableHoverableContent>
           {#snippet children()}
             <button
-              class="sceneControls__layer {stageProps.activeLayer === MapLayerType.Measurement &&
-                'sceneControls__layer--isActive'}"
-              onclick={() => {
-                const newPopoverId = handleSelectActiveControl('measurement');
-                openPopoverId = newPopoverId;
-              }}
+              class="sceneControls__layer {activeControl === 'measurement' ? 'sceneControls__layer--isActive' : ''}"
+              onclick={() => handleSelectActiveControl('measurement')}
             >
               <Icon Icon={IconRuler} size="1.5rem" stroke={2} />
             </button>
@@ -307,7 +367,7 @@
               {party}
               {gameSession}
               {selectedScene}
-              onSelectedChange={() => handleSelectActiveControl('measurement')}
+              onSelectedChange={() => handleSelectActiveControl('measurement', { toggle: false })}
             />
           {/snippet}
           {#snippet toolTipContent()}
@@ -316,148 +376,160 @@
         </ToolTip>
       </div>
     </div>
-    <div class="sceneControls__item sceneControls__item--marker">
-      <ToolTip positioning={{ placement: 'bottom' }} openDelay={500} closeOnPointerDown disableHoverableContent>
-        {#snippet children()}
-          <button
-            data-testid="markerToolButton"
-            class="sceneControls__layer {stageProps.activeLayer === MapLayerType.Marker &&
-              'sceneControls__layer--isActive'}"
-            onclick={() => {
-              const newPopoverId = handleSelectActiveControl('marker');
-              openPopoverId = newPopoverId;
-            }}
+    {#if !isCompact}
+      <div class="sceneControls__item sceneControls__item--marker">
+        <ToolTip positioning={{ placement: 'bottom' }} openDelay={500} closeOnPointerDown disableHoverableContent>
+          {#snippet children()}
+            <button
+              data-testid="markerToolButton"
+              class="sceneControls__layer {activeControl === 'marker' ? 'sceneControls__layer--isActive' : ''}"
+              onclick={() => handleSelectActiveControl('marker')}
+            >
+              <Icon Icon={IconPokerChip} size="1.5rem" />
+              <span class="sceneControls__layerText">Marker</span>
+            </button>
+          {/snippet}
+          {#snippet toolTipContent()}
+            Place markers to note points of interest on the map with notes.
+          {/snippet}
+        </ToolTip>
+      </div>
+      <div class="sceneControls__item sceneControls__item--annotation">
+        <ToolTip positioning={{ placement: 'bottom' }} openDelay={500} closeOnPointerDown disableHoverableContent>
+          {#snippet children()}
+            <button
+              class="sceneControls__layer {activeControl === 'annotation' ? 'sceneControls__layer--isActive' : ''}"
+              onclick={() => handleSelectActiveControl('annotation')}
+            >
+              <Icon Icon={IconPencil} size="1.5rem" />
+              <span class="sceneControls__layerText">Draw</span>
+            </button>
+          {/snippet}
+          {#snippet toolTipContent()}
+            Draw freehand annotations on the map
+          {/snippet}
+        </ToolTip>
+      </div>
+      <div class="sceneControls__item sceneControls__item--light">
+        <ToolTip positioning={{ placement: 'bottom' }} openDelay={500} closeOnPointerDown disableHoverableContent>
+          {#snippet children()}
+            <button
+              data-testid="lightToolButton"
+              class="sceneControls__layer {activeControl === 'light' ? 'sceneControls__layer--isActive' : ''}"
+              onclick={() => handleSelectActiveControl('light')}
+            >
+              <Icon Icon={IconFlame} size="1.5rem" />
+              <span class="sceneControls__layerText">Light</span>
+            </button>
+          {/snippet}
+          {#snippet toolTipContent()}
+            Place light sources on the map for atmospheric effects.
+          {/snippet}
+        </ToolTip>
+      </div>
+      {#each popoverControls as scene}
+        <div class="sceneControls__item">
+          <Popover
+            positioning={{ placement: 'bottom', gutter: 8 }}
+            isOpen={activeControl === scene.id}
+            onIsOpenChange={handleToolPopoverChange(scene.id)}
           >
-            <Icon Icon={IconPokerChip} size="1.5rem" />
-            <span class="sceneControls__layerText">Marker</span>
-          </button>
-        {/snippet}
-        {#snippet toolTipContent()}
-          Place markers to note points of interest on the map with notes.
-        {/snippet}
-      </ToolTip>
-    </div>
-    <div class="sceneControls__item sceneControls__item--annotation">
-      <ToolTip positioning={{ placement: 'bottom' }} openDelay={500} closeOnPointerDown disableHoverableContent>
-        {#snippet children()}
-          <button
-            class="sceneControls__layer {stageProps.activeLayer === MapLayerType.Annotation &&
-              'sceneControls__layer--isActive'}"
-            onclick={() => {
-              const newPopoverId = handleSelectActiveControl('annotation');
-              openPopoverId = newPopoverId;
-            }}
-          >
-            <Icon Icon={IconPencil} size="1.5rem" />
-            <span class="sceneControls__layerText">Draw</span>
-          </button>
-        {/snippet}
-        {#snippet toolTipContent()}
-          Draw freehand annotations on the map
-        {/snippet}
-      </ToolTip>
-    </div>
-    <div class="sceneControls__item sceneControls__item--light">
-      <ToolTip positioning={{ placement: 'bottom' }} openDelay={500} closeOnPointerDown disableHoverableContent>
-        {#snippet children()}
-          <button
-            data-testid="lightToolButton"
-            class="sceneControls__layer {stageProps.activeLayer === MapLayerType.Light &&
-              'sceneControls__layer--isActive'}"
-            onclick={() => {
-              const newPopoverId = handleSelectActiveControl('light');
-              openPopoverId = newPopoverId;
-            }}
-          >
-            <Icon Icon={IconFlame} size="1.5rem" />
-            <span class="sceneControls__layerText">Light</span>
-          </button>
-        {/snippet}
-        {#snippet toolTipContent()}
-          Place light sources on the map for atmospheric effects.
-        {/snippet}
-      </ToolTip>
-    </div>
-    {#each sceneControlArray as scene}
-      <!-- Regular popover controls for other tools -->
-      <div class="sceneControls__item">
+            {#snippet trigger()}
+              <ToolTip positioning={{ placement: 'bottom' }} openDelay={500} closeOnPointerDown disableHoverableContent>
+                {#snippet children()}
+                  <div class="sceneControls__trigger">
+                    <div
+                      class="sceneControls__layer {activeControl === scene.id ? 'sceneControls__layer--isActive' : ''}"
+                    >
+                      <Icon Icon={scene.icon} size="1.5rem" stroke={2} class="sceneControls__layerBtn" />
+                      <span class="sceneControls__layerText">
+                        {scene.text}
+                      </span>
+                    </div>
+                  </div>
+                {/snippet}
+                {#snippet toolTipContent()}
+                  {scene.tooltip}
+                {/snippet}
+              </ToolTip>
+            {/snippet}
+            {#snippet content()}
+              {@render toolControls(scene.id)}
+            {/snippet}
+          </Popover>
+        </div>
+      {/each}
+    {:else}
+      <div class="sceneControls__item sceneControls__item--overflow">
         <Popover
           positioning={{ placement: 'bottom', gutter: 8 }}
-          isOpen={openPopoverId === scene.id}
-          onIsOpenChange={handlePopoverOpenChange(scene.id)}
+          isOpen={overflowListOpen || overflowToolActive}
+          onIsOpenChange={handleOverflowOpenChange}
         >
           {#snippet trigger()}
-            <ToolTip positioning={{ placement: 'bottom' }} openDelay={500} closeOnPointerDown disableHoverableContent>
-              {#snippet children()}
-                <div class="sceneControls__trigger">
-                  <div
-                    class="sceneControls__layer {openPopoverId === scene.id ? 'sceneControls__layer--isActive' : ''}"
-                  >
-                    <Icon
-                      Icon={scene.id === 'play'
-                        ? party.gameSessionIsPaused
-                          ? IconScreenShareOff
-                          : IconScreenShare
-                        : scene.icon}
-                      size="1.5rem"
-                      stroke={2}
-                      class="sceneControls__layerBtn"
-                    />
-                    <span class="sceneControls__layerText">
-                      {scene.text}
-                    </span>
-                  </div>
-                </div>
-              {/snippet}
-              {#snippet toolTipContent()}
-                {scene.tooltip}
-              {/snippet}
-            </ToolTip>
+            <div class="sceneControls__trigger">
+              <div
+                data-testid="sceneControlsOverflowButton"
+                class="sceneControls__layer {overflowAnyActive ? 'sceneControls__layer--isActive' : ''}"
+              >
+                <Icon Icon={IconDots} size="1.5rem" stroke={2} />
+              </div>
+            </div>
           {/snippet}
           {#snippet content()}
-            {#if scene.id === 'grid'}
-              <GridControls
-                {stageProps}
-                {handleSelectActiveControl}
-                {activeControl}
-                {party}
-                {gameSession}
-                {stage}
-                {selectedScene}
-                {activeSceneId}
-                {handleMapFill}
-                {handleMapFit}
-                {errors}
-              />
-            {:else if scene.id === 'fog'}
-              <FogControls {stage} {stageProps} {onFogClear} />
-            {:else if scene.id === 'map'}
-              <MapControls
-                {stage}
-                {stageProps}
-                {handleSelectActiveControl}
-                {activeControl}
-                {party}
-                {selectedScene}
-                {activeSceneId}
-                {handleMapFill}
-                {handleMapFit}
-                {errors}
-                {client}
-              />
-            {:else if scene.id === 'play'}
-              <PlayControls {party} {selectedScene} {activeSceneId} {client} />
-            {:else if scene.id === 'weather'}
-              <WeatherControls {stageProps} {errors} />
-            {:else if scene.id === 'edge'}
-              <EdgeControls {stageProps} {errors} {party} />
-            {:else if scene.id === 'effects'}
-              <EffectsControls {stageProps} {errors} {party} />
+            {#if overflowToolActive && !overflowListOpen}
+              {@render toolControls(activeControl)}
+            {:else}
+              <div class="sceneControls__overflowList">
+                {#each drawingOverflowItems as item}
+                  {@render overflowItem(item.id, item.icon, item.text, item.testId)}
+                {/each}
+                {#each popoverControls as scene}
+                  {@render overflowItem(scene.id, scene.icon, scene.text, undefined)}
+                {/each}
+              </div>
             {/if}
           {/snippet}
         </Popover>
       </div>
-    {/each}
+    {/if}
+    <div class="sceneControls__item">
+      <Popover
+        positioning={{ placement: 'bottom', gutter: 8 }}
+        isOpen={activeControl === playControl.id}
+        onIsOpenChange={handleToolPopoverChange(playControl.id)}
+      >
+        {#snippet trigger()}
+          <ToolTip positioning={{ placement: 'bottom' }} openDelay={500} closeOnPointerDown disableHoverableContent>
+            {#snippet children()}
+              <div class="sceneControls__trigger">
+                <div
+                  class="sceneControls__layer {activeControl === playControl.id
+                    ? 'sceneControls__layer--isActive'
+                    : ''}"
+                >
+                  <Icon
+                    Icon={party.gameSessionIsPaused ? IconScreenShareOff : IconScreenShare}
+                    size="1.5rem"
+                    stroke={2}
+                    class="sceneControls__layerBtn"
+                  />
+                  <span class="sceneControls__layerText">
+                    {playControl.text}
+                  </span>
+                </div>
+              </div>
+            {/snippet}
+            {#snippet toolTipContent()}
+              {playControl.tooltip}
+            {/snippet}
+          </ToolTip>
+        {/snippet}
+        {#snippet content()}
+          <PlayControls {party} {selectedScene} {activeSceneId} {client} />
+        {/snippet}
+      </Popover>
+    </div>
   </div>
 </ColorMode>
 
@@ -545,6 +617,25 @@
   .sceneControls__trigger {
     display: flex;
     align-items: center;
+  }
+  /* Tool controls panels are taller than a phone viewport; keep them scrollable */
+  .sceneControls__item--overflow :global(.popContent) {
+    max-height: 50dvh;
+    overflow-y: auto;
+  }
+  .sceneControls__overflowList {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    min-width: 10rem;
+  }
+  .sceneControls__layer--overflow {
+    width: 100%;
+    font-size: 0.85rem;
+    font-weight: 700;
+  }
+  .sceneControls__overflowLabel {
+    white-space: nowrap;
   }
 
   @container stageWrapper (max-width: 1120px) {

--- a/apps/web/src/lib/utils/stageKeyCommands.ts
+++ b/apps/web/src/lib/utils/stageKeyCommands.ts
@@ -63,7 +63,7 @@ export function handleKeyCommands(
       deleteRoomAtCursor: () => void;
     };
   },
-  handleSelectActiveControl: (control: string) => string | null,
+  handleSelectActiveControl: (control: string) => void,
   clearFog?: () => void
 ): string {
   const { activeLayer, fogOfWar } = stageProps;

--- a/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
+++ b/apps/web/src/routes/(app)/[party]/[gameSession]/[[selectedScene]]/+page.svelte
@@ -348,11 +348,9 @@
   let stageIsLoading = $state(true);
   let isCursorInScene = $state(false);
   let activeControl = $state('none');
-  let keyboardPopoverId = $state<string | null>(null);
   let selectedMarkerId: string | undefined = $state();
   let selectedLightId: string | undefined = $state();
   let selectedAnnotationId: string | undefined = $state();
-  let activeElement: HTMLElement | null = $state(null);
   let innerWidth: number = $state(1000);
   let hoveredMarker: HoveredMarker | null = $state(null);
 
@@ -528,7 +526,9 @@
   // Tool selection
   // ---------------------------------------------------------------------------
 
-  const handleSelectActiveControl = (control: string, openPopover?: string | null): string | null => {
+  const handleSelectActiveControl = (control: string, opts: { toggle?: boolean } = {}): void => {
+    if (control === activeControl && opts.toggle === false) return;
+
     if (activeControl === 'light') selectedLightId = undefined;
 
     if (control === activeControl) {
@@ -537,7 +537,7 @@
       if (control === 'annotation') {
         queuePropertyUpdate(stageProps, ['annotations', 'activeLayer'], null, 'control');
       }
-      return null;
+      return;
     }
 
     activeControl = control;
@@ -569,8 +569,6 @@
       queuePropertyUpdate(stageProps, ['activeLayer'], MapLayerType.None, 'control');
       queuePropertyUpdate(stageProps, ['annotations', 'activeLayer'], null, 'control');
     }
-
-    return openPopover !== undefined ? openPopover : control;
   };
 
   // Auto-manage annotation layer activation (create-on-first-use)
@@ -608,6 +606,13 @@
     if (stageProps.activeLayer === MapLayerType.Marker && activeControl !== 'marker') {
       activeControl = 'marker';
       markersPane.expand();
+    }
+  });
+
+  // MeasurementControls writes activeLayer directly; keep the toolbar highlight in sync
+  $effect(() => {
+    if (stageProps.activeLayer === MapLayerType.Measurement && activeControl !== 'measurement') {
+      activeControl = 'measurement';
     }
   });
 
@@ -1048,6 +1053,7 @@
   const onFogRoomAdd = (points: { x: number; y: number }[]) => {
     const rooms = [...stageProps.fogOfWar.rooms, { id: crypto.randomUUID(), points, enabled: true }];
     queuePropertyUpdate(stageProps, ['fogOfWar', 'rooms'], rooms, 'control');
+    trackChecklistItemLocal('fog-room');
   };
 
   // Room toggling works from any layer, so a right-click on a marker inside a
@@ -1265,6 +1271,7 @@
   // Keyboard -------------------------------------------------------------------
 
   const handleKeydown = (event: KeyboardEvent) => {
+    const activeElement = document.activeElement as HTMLElement | null;
     if (
       activeElement &&
       (activeElement.tagName === 'INPUT' ||
@@ -1299,8 +1306,7 @@
       }
     }
 
-    const previousControl = activeControl;
-    const newActiveControl = handleKeyCommands(
+    activeControl = handleKeyCommands(
       event,
       stageProps,
       activeControl,
@@ -1308,14 +1314,6 @@
       handleSelectActiveControl,
       clearFogAndRooms
     );
-    activeControl = newActiveControl;
-
-    if (
-      previousControl !== newActiveControl ||
-      ['erase', 'marker', 'annotation', 'measurement', 'none'].includes(newActiveControl)
-    ) {
-      keyboardPopoverId = null;
-    }
   };
 
   // Drawing slider handlers - bound from AnnotationManager
@@ -1376,11 +1374,7 @@
 
 <!-- Every new pointer gesture starts a new undo step (capture phase: fires before
      stage/panel handlers write, so the previous capture group closes first) -->
-<svelte:document
-  onkeydown={handleKeydown}
-  onpointerdowncapture={() => session.client?.stopCapturing()}
-  bind:activeElement
-/>
+<svelte:document onkeydown={handleKeydown} onpointerdowncapture={() => session.client?.stopCapturing()} />
 <svelte:window bind:innerWidth />
 <Head title={gameSession.name} description={`${gameSession.name} on Table Slayer`} />
 
@@ -1538,7 +1532,7 @@
           party={currentParty}
           {gameSession}
           client={session.client}
-          {keyboardPopoverId}
+          isCompact={isMobile}
           onFogClear={clearFogAndRooms}
         />
         <SceneZoom {stage} {handleSceneFit} {handleMapFill} {stageProps} />

--- a/apps/web/tests/e2e/checklist.auth.test.ts
+++ b/apps/web/tests/e2e/checklist.auth.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Locator } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 import {
   activateMarkerTool,
   clickCanvasCenter,
@@ -7,11 +7,12 @@ import {
   waitForSceneEditor
 } from './helpers/test-helpers';
 
-// Helper to extract progress count from text like "5 / 18"
-const getProgressCount = async (progress: Locator): Promise<number> => {
-  const text = await progress.textContent();
-  const match = text?.match(/(\d+)\s*\/\s*\d+/);
-  return match ? parseInt(match[1], 10) : 0;
+// Helper to count completed items (checkboxes showing a check icon)
+const getCompletedCount = async (page: Page): Promise<number> => {
+  return page
+    .getByTestId('checklistItemCheckbox')
+    .filter({ has: page.locator('svg') })
+    .count();
 };
 
 test.describe('Checklist feature tour', () => {
@@ -37,13 +38,8 @@ test.describe('Checklist feature tour', () => {
     const checklist = page.getByTestId('checklist');
     await expect(checklist).toBeVisible({ timeout: 10000 });
 
-    // Verify progress indicator is visible and shows format "X / Y"
-    const progress = page.getByTestId('checklistProgress');
-    await expect(progress).toBeVisible();
-    await expect(progress).toContainText('/');
-
-    // Get the initial progress count
-    const initialCount = await getProgressCount(progress);
+    // Get the initial completed item count
+    const initialCount = await getCompletedCount(page);
 
     // The first uncompleted item is auto-expanded when the checklist opens
     const instructions = page.locator('.checklist__instructions').first();
@@ -79,9 +75,9 @@ test.describe('Checklist feature tour', () => {
       }
     }
 
-    // If we clicked an uncompleted checkbox, verify progress increased
+    // If we clicked an uncompleted checkbox, verify the completed count increased
     if (clickedCheckbox) {
-      const newCount = await getProgressCount(progress);
+      const newCount = await getCompletedCount(page);
       expect(newCount).toBeGreaterThan(initialCount);
     }
   });
@@ -188,10 +184,6 @@ test.describe('Checklist feature tour', () => {
     const checklist = page.getByTestId('checklist');
     await expect(checklist).toBeVisible({ timeout: 10000 });
 
-    // Get initial progress count
-    const progress = page.getByTestId('checklistProgress');
-    await expect(progress).toBeVisible();
-
     // Press 'T' to activate measurement tool
     await page.keyboard.press('t');
 
@@ -224,9 +216,8 @@ test.describe('Checklist feature tour', () => {
     const checklist = page.getByTestId('checklist');
     await expect(checklist).toBeVisible({ timeout: 10000 });
 
-    // Get current progress count
-    const progress = page.getByTestId('checklistProgress');
-    const initialCount = await getProgressCount(progress);
+    // Get current completed item count
+    const initialCount = await getCompletedCount(page);
 
     // Find and click an uncompleted checkbox
     const checkboxes = page.getByTestId('checklistItemCheckbox');
@@ -243,9 +234,9 @@ test.describe('Checklist feature tour', () => {
       }
     }
 
-    // If we clicked a checkbox, verify the progress increased
+    // If we clicked a checkbox, verify the completed count increased
     if (clickedItemIndex >= 0) {
-      const newCount = await getProgressCount(progress);
+      const newCount = await getCompletedCount(page);
       expect(newCount).toBeGreaterThan(initialCount);
 
       // Wait for the mutation to persist
@@ -266,7 +257,7 @@ test.describe('Checklist feature tour', () => {
       await expect(checklist).toBeVisible({ timeout: 10000 });
 
       // Verify completion persisted - count should be at least what it was after clicking
-      const persistedCount = await getProgressCount(progress);
+      const persistedCount = await getCompletedCount(page);
       expect(persistedCount).toBeGreaterThanOrEqual(newCount);
 
       // Verify the item we clicked still shows as completed


### PR DESCRIPTION
The scene toolbar now has a "..." option to spread all the secondary items in the menu when in mobile mode. Before the toolbar was too large for mobile. I also added a tutorial for creating fog rooms, which were added in a previous PR.

<img width="797" height="535" alt="image" src="https://github.com/user-attachments/assets/1b7aeccf-1d56-4403-958b-f6eb18ed20fc" />
